### PR TITLE
Pin NordVPN API host routes via eth0 to fix reconnect deadlock

### DIFF
--- a/root/etc/s6-overlay/s6-rc.d/init-firewall/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-firewall/run
@@ -37,6 +37,14 @@ if [ -n "$docker_network" ]; then
         for ip in $nordvpnapi_ip; do
             [ -z "$ip" ] && continue
             run4 -A OUTPUT -d "$ip" -p tcp --dport 443 -j ACCEPT
+            # Pin a host route via eth0 so API traffic stays off the tunnel.
+            # wg-quick's policy routing sends everything through wg0, but its
+            # 'suppress_prefixlength 0' rule lets specific main-table routes
+            # win. Without this route a dead tunnel makes the API unreachable,
+            # and vpn-reconnect can never fetch the key/server list to recover.
+            if [ -n "$gw" ]; then
+                ip route add "$ip" via "$gw" dev eth0 2>/dev/null || true
+            fi
         done
         IFS="$oldIFS"
     fi


### PR DESCRIPTION
## Problem

Once wg0 is up, wg-quick policy routing sends **all** traffic — including NordVPN API calls — through the tunnel. If the tunnel dies mid-life (the server stops responding), every scheduled `vpn-reconnect` fails at the private key fetch: the API request is routed into the dead tunnel and times out (20s = 2 API IPs × 10s connect timeout), so `vpn-config --fail-fast` aborts and reconnect exits with "keeping current connection" — keeping the dead tunnel forever. The container stays unhealthy with no way to self-recover, and `CHECK_CONNECTION_CRON` can't help because its recovery path is the same deadlocked `vpn-reconnect`.

Observed in production 2026-07-10: tunnel died right after startup (one handshake, ~1 KiB received), then three consecutive `RECREATE_VPN_CRON` runs failed with `CRITICAL: could not obtain WireGuard private key from NordVPN API (check TOKEN)` even though the token was valid.

## Fix

In `init-firewall`, alongside the existing API firewall accept rules, add a host route for each `NORDVPNAPI_IP` via the eth0 gateway. wg-quick's `suppress_prefixlength 0` rule lets specific main-table routes win over the tunnel default, so the API stays reachable regardless of tunnel state and reconnect can always fetch the key and server list. This is the same technique the script already uses for `NETWORK` CIDRs, and it only aligns routing with existing firewall intent — the API IPs were already allowlisted for direct eth0 egress (that's how the initial bootstrap works before wg0 exists).

## Verification

Local build with this change:
- `ip route get 104.16.208.203` → via eth0; `ip route get 1.1.1.1` → still via wg0.
- API curl returns 200 with the tunnel up.
- Simulated the incident by blackholing the peer endpoint (dead tunnel): `vpn-reconnect` now fetches the key in ~1s and swaps to a new server successfully (previously deadlocked).
- Kill-switch leak test: direct eth0 egress to non-API hosts still blocked.

The same route applied manually inside the affected production container restored connectivity via the previously stuck `vpn-reconnect` path.