### PR TITLE
Pin c-ares 1.34.8-r0 to fix CVE-2026-33630

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -97,6 +97,9 @@ LABEL org.opencontainers.image.authors="Alexander Zinchenko <alexander@zinchenko
 ENV S6_CMD_WAIT_FOR_SERVICES_MAXTIME=120000
 
 RUN echo "**** install security fix packages ****" && \
+    apk --no-cache --no-progress add \
+        c-ares=1.34.8-r0 \
+        && \
     echo "**** install mandatory packages ****" && \
     echo "Target platform: ${TARGETPLATFORM}" && \
     apk --no-cache --no-progress add \


### PR DESCRIPTION
## Problem

Code scanning ([Trivy alert #39](https://github.com/azinchen/nordvpn-wg/security/code-scanning/39)) flags the published image for **CVE-2026-33630** (HIGH): a use-after-free / double-free in c-ares query-completion handling, exploitable via crafted DNS responses over TCP through `ares_getaddrinfo()`. The image ships c-ares **1.34.6-r0**, which comes in only as a libcurl dependency and is therefore not covered by the Dockerfile's version pins.

## Fix

Pin `c-ares=1.34.8-r0` (the fixed version in Alpine 3.24) in the security-fix packages block of the main image stage. `scripts/update-apk-versions.sh` extracts pins from all `apk add` blocks, so the new pin is maintained by the existing update automation like every other package.

## Verification

- Built the image: `apk info c-ares` reports **1.34.8-r0**.
- curl (the c-ares consumer) works: API request through the built image returns 200.
- Ran `scripts/update-apk-versions.sh` against the updated Dockerfile: it detects the c-ares pin and reports it up-to-date, no other changes.