### PR TITLE
ci: replace wiki submodule with in-repo folder synced by workflow

### DIFF
--- a/.github/workflows/wiki-publish.yml
+++ b/.github/workflows/wiki-publish.yml
@@ -1,0 +1,58 @@
+name: Docs - Publish Wiki
+
+on:
+  push:
+    # Publish on every release (tag) push
+    tags: [ '**' ]
+  workflow_dispatch:
+    # Manual publish from any branch or tag
+
+permissions:
+  contents: write  # Required to push to the wiki repository
+
+jobs:
+  publish-wiki:
+    name: 📚 Publish Wiki
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7.0.0
+
+      - name: Determine published version
+        id: version
+        run: |
+          # The tag or branch the workflow runs on (push tag or dispatch ref)
+          VERSION="${{ github.ref_name }}"
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          echo "Publishing wiki for version: ${VERSION}"
+
+      - name: Clone wiki repository
+        run: |
+          git clone "https://x-access-token:${{ github.token }}@github.com/${{ github.repository }}.wiki.git" wiki-repo
+
+      - name: Sync wiki content
+        run: |
+          # Replace/add/delete: make the wiki repo mirror the wiki/ folder exactly
+          rsync -av --delete --exclude '.git' wiki/ wiki-repo/
+
+      - name: Commit and push
+        working-directory: wiki-repo
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git add -A
+          if git diff --cached --quiet; then
+            echo "No wiki changes - pushing empty marker commit"
+            git commit --allow-empty -m "Publish wiki for ${{ steps.version.outputs.version }} (no content changes)"
+          else
+            git commit -m "Publish wiki for ${{ steps.version.outputs.version }}"
+          fi
+
+          git push origin HEAD:master
+
+      - name: Publish summary
+        run: |
+          echo "✅ Wiki published for version ${{ steps.version.outputs.version }}"
+          echo "   https://github.com/${{ github.repository }}/wiki"

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "wiki"]
-	path = wiki
-	url = ../nordvpn-wg.wiki.git

--- a/wiki/Architecture-and-Internals.md
+++ b/wiki/Architecture-and-Internals.md
@@ -1,0 +1,176 @@
+This page describes how the container works internally. Useful for contributors, debugging, and understanding the boot sequence.
+
+## Boot Sequence
+
+The container uses [s6-overlay](https://github.com/just-containers/s6-overlay) for process supervision. Services start in a defined order:
+
+```
+entrypoint (container start)
+  │
+  ├─ init-firewall       Apply iptables rules (depends on entrypoint backend selection)
+  ├─ init-setupcron      Configure cron jobs from RECREATE_VPN_CRON / CHECK_CONNECTION_CRON
+  │
+  ├─ svc-nordvpn         Main WireGuard service (long-running)
+  └─ svc-cron            Cron daemon (long-running)
+```
+
+## Key Scripts
+
+### `entrypoint` — Backend selection & default-deny
+
+Location: `/usr/local/bin/entrypoint`
+
+1. Tests nft and legacy iptables backends by toggling a chain policy (`DROP` ↔ `ACCEPT` on `OUTPUT`)
+2. If the preferred backend fails, tests the fallback
+3. If legacy is selected and nft tables already contain rules, flushes nft tables to avoid mixed stacks
+4. Exports selected backends (`IPT`, `IP6T`) to `/run/xt/backend.env`
+5. Sets `INPUT`, `OUTPUT`, `FORWARD` to `DROP` on both IPv4 and IPv6
+6. Allows loopback traffic
+
+Backend preference:
+
+| Preferred backend | Fallback |
+|-------------------|----------|
+| **nft** (`iptables`) | legacy (`iptables-legacy`) |
+
+The container prefers the nft backend and falls back to legacy only if nft
+isn't usable in its network namespace (the probe in step 1 decides this).
+
+### `backend-functions` — Shared utilities
+
+Location: `/usr/local/bin/backend-functions`
+
+Sourced by every script. Provides the environment-variable defaults (including `dns`, `network`, `forward_from`, `nordvpnapi_ip`) and:
+- `run4()` / `run6()` — Execute iptables commands with logging (non-fatal)
+- `run4_critical()` / `run6_critical()` — Execute or sleep forever on failure
+- `is_vpn_connected()` — Checks for the `wg0` interface
+- `log()` / `log_error()` / `log_warning()` — Timestamped logging
+- `parse_cron()` — Converts cron expressions to human-readable descriptions
+
+### `vpn-config` — Key retrieval & server selection
+
+Location: `/usr/local/bin/vpn-config`
+
+1. Fetches your NordLynx (WireGuard) **private key** from the NordVPN API using `TOKEN`
+   (`v1/users/services/credentials`), via pinned API IPs (no DNS). The key is not cached —
+   it is re-fetched on every connect.
+2. Resolves COUNTRY/CITY/GROUP to numeric IDs using the JSON data files
+3. Builds the NordVPN API query (always filtered to NordLynx, tech id 35); CITY uses the
+   `country_city_id` filter
+4. Fetches the server list using pinned API IPs (no DNS)
+5. Detects specific server hostnames and gives them `load=0`
+6. Sorts by load (multi-location) or keeps API order (single location)
+7. Applies `RANDOM_TOP` if set
+8. Writes the selected server's WireGuard config to `/etc/wireguard/wg0.conf` (private key,
+   `Address`, `[Peer]` endpoint + public key, `AllowedIPs = 0.0.0.0/0`, `PersistentKeepalive = 25`)
+
+### `svc-nordvpn/run` — WireGuard launcher
+
+Location: `/etc/s6-overlay/s6-rc.d/svc-nordvpn/run`
+
+1. Calls `vpn-config` to generate `wg0.conf`
+2. Adds a temporary pinhole in the `VPN-SERVER` chain for the server IP (UDP/51820 on eth0)
+3. Brings the tunnel up with `wg-quick up wg0`
+4. Writes `/etc/resolv.conf` from `$dns` (Docker's embedded resolver is unreachable behind
+   the kill switch)
+5. Waits for the connection (checks `wg0`, up to ~60 seconds)
+6. Optionally runs network diagnostics (`NETWORK_DIAGNOSTIC_ENABLED`)
+7. Blocks (`sleep infinity`) to keep the service alive
+
+> The WireGuard config intentionally omits a `DNS =` line — `wg-quick`'s `resolvconf` step
+> fails inside Docker, so DNS is managed directly (step 4) instead.
+
+### `svc-nordvpn/finish` — Cleanup on disconnect
+
+Brings `wg0` down and flushes the `VPN-SERVER` chain so a fresh connect starts clean.
+
+### `vpn-healthcheck` — Connection monitoring
+
+Location: `/usr/local/bin/vpn-healthcheck`
+
+1. Sends HTTP requests to the configured URL(s)
+2. Retries `CHECK_CONNECTION_ATTEMPTS` times with configurable interval
+3. If all fail, calls `vpn-reconnect`
+
+### `vpn-reconnect` — Service restart
+
+Location: `/usr/local/bin/vpn-reconnect`
+
+1. Stops `svc-nordvpn` via s6-rc
+2. Waits briefly
+3. Restarts `svc-nordvpn` (which re-fetches the key and picks a new server)
+
+### `network-diagnostic` — Debug tool
+
+Location: `/usr/local/bin/network-diagnostic`
+
+Two modes:
+- `--basic`: Public IP + geolocation only
+- `--full` (default): Complete diagnostics including interfaces, iptables rules, DNS, routes, WireGuard status, and kernel version
+
+## Data Files
+
+Located in `/usr/local/share/nordvpn/data/`:
+
+| File | Purpose |
+|------|---------|
+| `countries.json` | Country name/code/ID mappings |
+| `groups.json` | Server group definitions |
+| `technologies.json` | VPN technology definitions |
+
+> **Origin of these files:** They are generated from the NordVPN public API (`https://api.nordvpn.com/`), not maintained by hand, and are refreshed automatically by the [`maintenance-updates`](https://github.com/azinchen/nordvpn-wg/actions/workflows/maintenance-updates.yml) GitHub Actions workflow, which opens a pull request when NordVPN changes its API schema. **Do not edit them by hand** — manual changes are overwritten the next time the workflow runs.
+
+## State Files
+
+| Path | Purpose |
+|------|---------|
+| `/run/xt/backend.env` | Selected iptables backend (IPT, IP6T) |
+| `/etc/wireguard/wg0.conf` | Current server's WireGuard config (private key, peer, endpoint) |
+
+## Connection Status
+
+WireGuard is a silent protocol with no management socket. Status comes from the kernel:
+
+- `wg show wg0` — peer endpoint, last handshake, transfer counters
+- `is_vpn_connected()` checks only that the `wg0` link exists; a real connection also needs a
+  recent handshake and non-zero `received` bytes
+
+## Firewall Build Phases
+
+### Phase 1 — Entrypoint (default-deny)
+
+The `entrypoint` script runs first and:
+- Selects the iptables backend (nft or legacy — see [Firewall Backends](Firewall-Backends))
+- Sets `INPUT`, `OUTPUT`, and `FORWARD` policies to `DROP` on both IPv4 and IPv6
+- Allows loopback traffic (required for inter-process communication)
+
+At this point, **all network traffic is blocked**.
+
+### Phase 2 — init-firewall (allow VPN + exceptions)
+
+The `init-firewall` service then:
+- Detects the Docker network (eth0 subnet and gateway)
+- Enables connection tracking (ESTABLISHED/RELATED)
+- Sets up MASQUERADE on the `wg0` (VPN) interface
+- Creates a `VPN-SERVER` chain and jumps eth0 UDP/51820 to it
+- Adds NordVPN API IP exceptions (TCP/443 only) from `NORDVPNAPI_IP`
+- If `NETWORK` is set, adds static routes and bidirectional allow rules for those CIDRs
+- If `FORWARD_FROM` is set, opens `FORWARD` for those CIDRs over `wg0` (see [VPN Gateway Mode](VPN-Gateway-Mode))
+
+### Phase 3 — svc-nordvpn (per-connection pinhole)
+
+When connecting:
+- The VPN server IP gets a temporary rule in the `VPN-SERVER` chain (UDP/51820 on eth0)
+- When the connection drops, `svc-nordvpn/finish` flushes that chain
+
+## Firewall Chain Structure
+
+```
+INPUT chain:  ACCEPT lo → ACCEPT ESTABLISHED,RELATED → [NETWORK CIDRs] → DROP
+OUTPUT chain: ACCEPT lo → ACCEPT ESTABLISHED,RELATED → ACCEPT wg0 → VPN-SERVER (eth0 udp/51820) → [NORDVPNAPI IPs] → [NETWORK CIDRs] → DROP
+FORWARD chain: ACCEPT ESTABLISHED,RELATED → [FORWARD_FROM CIDRs over wg0] → DROP
+
+VPN-SERVER chain: [temporary rule for the current VPN server IP]
+
+NAT/POSTROUTING: MASQUERADE on wg0
+```

--- a/wiki/Automatic-Reconnection.md
+++ b/wiki/Automatic-Reconnection.md
@@ -1,0 +1,70 @@
+The container supports three reconnection mechanisms: scheduled switching, connection failure handling, and health monitoring.
+
+## Scheduled Reconnection
+
+Use `RECREATE_VPN_CRON` to periodically switch to a different server. This uses standard cron syntax.
+
+```bash
+# Reconnect every 6 hours at minute 0
+-e RECREATE_VPN_CRON="0 */6 * * *"
+
+# Reconnect daily at 3 AM
+-e RECREATE_VPN_CRON="0 3 * * *"
+
+# Reconnect every 4 hours
+-e RECREATE_VPN_CRON="0 */4 * * *"
+```
+
+When triggered, the cron job stops the `svc-nordvpn` service, which causes it to restart automatically. On restart, `vpn-config` re-fetches the server list and selects a new server based on current load.
+
+## Connection Failure Handling
+
+WireGuard is a connectionless, "silent" protocol — there is no session that errors out when the path dies, so failures don't restart the service on their own. The generated config sets `PersistentKeepalive = 25` to keep NAT mappings alive, but detecting a dead tunnel relies on **health monitoring** (below): when probes fail, the `svc-nordvpn` service is restarted and `vpn-config` selects a new server.
+
+If you want servers rotated even without failures, combine health monitoring with scheduled reconnection (`RECREATE_VPN_CRON`).
+
+## Connection Health Monitoring
+
+Use the `CHECK_CONNECTION_*` variables for active health probing:
+
+```bash
+-e CHECK_CONNECTION_CRON="*/5 * * * *"
+-e CHECK_CONNECTION_URL="https://1.1.1.1;https://8.8.8.8"
+-e CHECK_CONNECTION_ATTEMPTS=3
+-e CHECK_CONNECTION_ATTEMPT_INTERVAL=10
+```
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `CHECK_CONNECTION_CRON` | Disabled | Cron schedule for health checks |
+| `CHECK_CONNECTION_URL` | `https://www.google.com` | URLs to probe (semicolon-separated) |
+| `CHECK_CONNECTION_ATTEMPTS` | `5` | Number of retry attempts |
+| `CHECK_CONNECTION_ATTEMPT_INTERVAL` | `10` | Seconds between retries |
+
+## Docker Health Status
+
+The image ships a Docker [`HEALTHCHECK`](https://docs.docker.com/reference/dockerfile/#healthcheck) that reports the container's health (`healthy` / `unhealthy`) to Docker, Compose `depends_on: condition: service_healthy`, Swarm/Kubernetes, and monitoring or autoheal sidecars. It is **observational only** — it never reconnects. Active recovery is handled separately by `CHECK_CONNECTION_*` and `RECREATE_VPN_CRON`.
+
+It is **opt-in**: while disabled (the default) the probe always reports healthy without testing anything. Set `HEALTHCHECK_ENABLED=true` to activate it.
+
+```bash
+-e HEALTHCHECK_ENABLED=true
+```
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `HEALTHCHECK_ENABLED` | `false` | Enable the Docker `HEALTHCHECK` probe. When disabled, the container always reports healthy. |
+
+When enabled, the probe checks that the `wg0` interface exists and that a single short request to `CHECK_CONNECTION_URL` succeeds. The probe runs every 60s with a 60s start period and 3 retries before the container is marked `unhealthy`; unlike the cron `CHECK_CONNECTION_*` check it performs no retry loop of its own and never triggers a reconnect.
+
+## Recommended Setup
+
+For most users, combining scheduled reconnection with health monitoring provides robust connectivity:
+
+```yaml
+environment:
+  - RECREATE_VPN_CRON=0 */6 * * *           # Switch server every 6 hours
+  - CHECK_CONNECTION_CRON=*/5 * * * *       # Check every 5 minutes
+  - CHECK_CONNECTION_URL=https://1.1.1.1    # Fast, reliable endpoint
+  - CHECK_CONNECTION_ATTEMPTS=3
+```

--- a/wiki/Custom-DNS.md
+++ b/wiki/Custom-DNS.md
@@ -1,0 +1,72 @@
+By default, the container resolves names through NordVPN's own DNS servers (`103.86.96.100` and `103.86.99.100`), reached over the tunnel. These may apply regional filtering — for example, certain domains may be sinkholed when connected through some exit nodes.
+
+Because the kill-switch firewall makes Docker's embedded resolver (`127.0.0.11`) unreachable, the container writes its own `/etc/resolv.conf` after the tunnel comes up. This page covers how to override the DNS servers it uses.
+
+## Method 1: The `DNS` Variable (recommended)
+
+Set `DNS` to one or more servers (semicolon- or comma-separated). The container writes them to `/etc/resolv.conf` on every connect:
+
+```yaml
+services:
+  vpn:
+    environment:
+      - DNS=1.1.1.1,1.0.0.1
+```
+
+- Default (unset): `103.86.96.100;103.86.99.100` (NordVPN).
+- The servers must be reachable through the tunnel (any public resolver is) or via a `NETWORK` CIDR.
+
+## Method 2: Bind-Mount a Custom `resolv.conf`
+
+Mount a custom `resolv.conf` read-only. The container's attempt to rewrite it is rejected by the read-only mount (logged as a harmless warning), so your file stays in place:
+
+**1. Create a `resolv.conf` file:**
+
+```
+nameserver 1.1.1.1
+nameserver 1.0.0.1
+```
+
+**2. Mount it in your compose file:**
+
+```yaml
+services:
+  vpn:
+    volumes:
+      - ./resolv.conf:/etc/resolv.conf:ro
+```
+
+## Popular DNS Providers
+
+| Provider | Primary | Secondary |
+|----------|---------|-----------|
+| Cloudflare | `1.1.1.1` | `1.0.0.1` |
+| Google | `8.8.8.8` | `8.8.4.4` |
+| Quad9 | `9.9.9.9` | `149.112.112.112` |
+| OpenDNS | `208.67.222.222` | `208.67.220.220` |
+
+## Why Not Docker `dns:`?
+
+Docker's `dns:` option configures an internal resolver (`127.0.0.11`) that forwards to the specified servers. In VPN containers with strict firewall rules (kill switch), Docker's internal DNS resolver is flushed/unreachable, resulting in `connection refused` errors. Use one of the methods above instead.
+
+## Verifying Your DNS Configuration
+
+After the VPN connects, check which DNS servers are active:
+
+```bash
+docker exec vpn cat /etc/resolv.conf
+```
+
+Test resolution:
+
+```bash
+docker exec vpn nslookup example.com
+```
+
+Run the full network diagnostic to see DNS details:
+
+```bash
+docker exec vpn /usr/local/bin/network-diagnostic
+```
+
+The diagnostic output includes a **DNS configuration** section showing the active nameservers and their geolocation.

--- a/wiki/Docker-Compose-Examples.md
+++ b/wiki/Docker-Compose-Examples.md
@@ -1,0 +1,169 @@
+## Simple VPN + Application Setup
+
+```yaml
+services:
+  vpn:
+    image: azinchen/nordvpn-wg:latest
+    container_name: nordvpn
+    cap_add:
+      - NET_ADMIN
+    sysctls:
+      - net.ipv4.conf.all.src_valid_mark=1
+    environment:
+      - TOKEN=your_nordvpn_token_here
+      - COUNTRY=United States;CA;38
+      - CITY=New York;Los Angeles;Toronto
+      - RANDOM_TOP=10
+      - RECREATE_VPN_CRON=0 */6 * * *
+      - NETWORK=192.168.1.0/24
+    ports:
+      - "8080:8080"
+      - "3000:3000"
+    restart: unless-stopped
+
+  webapp:
+    image: nginx:alpine
+    container_name: webapp
+    network_mode: "service:vpn"
+    depends_on:
+      - vpn
+    volumes:
+      - ./html:/usr/share/nginx/html:ro
+    restart: unless-stopped
+
+  api-service:
+    image: node:alpine
+    container_name: api-service
+    network_mode: "service:vpn"
+    depends_on:
+      - vpn
+    working_dir: /app
+    volumes:
+      - ./app:/app
+    command: ["npm", "start"]
+    restart: unless-stopped
+```
+
+## Advanced Setup with Local Access
+
+```yaml
+services:
+  vpn:
+    image: azinchen/nordvpn-wg:latest
+    container_name: nordvpn
+    cap_add:
+      - NET_ADMIN
+    sysctls:
+      - net.ipv4.conf.all.src_valid_mark=1
+    environment:
+      - TOKEN=your_nordvpn_token_here
+      - COUNTRY=Netherlands;DE;209
+      - CITY=Amsterdam;Berlin;Frankfurt
+      - GROUP=Standard VPN servers
+      - RANDOM_TOP=5
+      - RECREATE_VPN_CRON=0 */4 * * *
+      - CHECK_CONNECTION_CRON=*/5 * * * *
+      - CHECK_CONNECTION_URL=https://1.1.1.1;https://8.8.8.8
+      - NETWORK=192.168.1.0/24;172.20.0.0/16
+    ports:
+      - "8080:8080"
+      - "3000:3000"
+      - "9000:9000"
+      - "6379:6379"
+    restart: unless-stopped
+
+  webapp:
+    image: nginx:alpine
+    container_name: webapp
+    network_mode: "service:vpn"
+    depends_on:
+      vpn:
+        condition: service_healthy
+    volumes:
+      - ./config/nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./web:/usr/share/nginx/html:ro
+    restart: unless-stopped
+
+  api-service:
+    image: node:alpine
+    container_name: api-service
+    network_mode: "service:vpn"
+    depends_on:
+      - vpn
+      - webapp
+    working_dir: /app
+    volumes:
+      - ./api:/app
+    command: ["npm", "start"]
+    restart: unless-stopped
+
+  redis:
+    image: redis:alpine
+    container_name: redis
+    network_mode: "service:vpn"
+    depends_on:
+      - vpn
+    volumes:
+      - ./config/redis:/data
+    restart: unless-stopped
+
+  # Service that DOESN'T use VPN (runs on host network)
+  monitoring:
+    image: grafana/grafana:latest
+    container_name: monitoring
+    network_mode: host
+    environment:
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+    volumes:
+      - ./config/grafana:/var/lib/grafana
+    restart: unless-stopped
+```
+
+## Web Proxy Setup
+
+```yaml
+services:
+  vpn:
+    image: azinchen/nordvpn-wg:latest
+    container_name: nordvpn
+    cap_add:
+      - NET_ADMIN
+    sysctls:
+      - net.ipv4.conf.all.src_valid_mark=1
+    environment:
+      - TOKEN=your_nordvpn_token_here
+      - COUNTRY=CA;38
+      - CITY=Toronto;Montreal
+      - NETWORK=192.168.1.0/24
+    restart: unless-stopped
+
+  app:
+    image: nginx:alpine
+    container_name: webapp
+    network_mode: "service:vpn"
+    depends_on:
+      - vpn
+    volumes:
+      - ./html:/usr/share/nginx/html
+    restart: unless-stopped
+
+  nginx-proxy:
+    image: nginx:alpine
+    container_name: proxy
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./nginx.conf:/etc/nginx/nginx.conf:ro
+    depends_on:
+      - vpn
+    restart: unless-stopped
+```
+
+## Key Concepts
+
+- **Ports must be published on the VPN container**, not on application containers using `network_mode: "service:vpn"`.
+- Use `depends_on` to ensure the VPN starts before dependent services.
+- Services that should **not** use the VPN can use `network_mode: host` or a separate Docker network.
+- When the VPN container restarts, all dependent containers must also be restarted. See [Updating and Maintenance](Updating-and-Maintenance#why-dependent-containers-must-restart).
+- WireGuard needs only `NET_ADMIN` plus the `net.ipv4.conf.all.src_valid_mark=1` sysctl so `wg-quick` can set its routing policy. `/dev/net/tun` and `SYS_ADMIN` are **not** required (kernel WireGuard, no userspace fallback) — see [Permissions](Permissions). If your host blocks the sysctl, `privileged: true` works as a last resort.

--- a/wiki/Docker-Run-Examples.md
+++ b/wiki/Docker-Run-Examples.md
@@ -1,0 +1,45 @@
+## Basic Example
+
+```bash
+docker run -d --name vpn \
+           --cap-add=NET_ADMIN \
+           --sysctl net.ipv4.conf.all.src_valid_mark=1 \
+           -e TOKEN=your_nordvpn_token_here \
+           azinchen/nordvpn-wg
+
+# Run application through VPN
+docker run -d --name app --net=container:vpn nginx
+```
+
+## Advanced Example with Port Mapping
+
+```bash
+docker run -d --name vpn \
+           --cap-add=NET_ADMIN \
+           --sysctl net.ipv4.conf.all.src_valid_mark=1 \
+           -p 8080:8080 \
+           -p 9091:9091 \
+           -e TOKEN=your_nordvpn_token_here \
+           -e COUNTRY="Germany;NL;202" \
+           -e CITY="Amsterdam;6076868;uk2567" \
+           -e GROUP="Standard VPN servers" \
+           -e RANDOM_TOP=3 \
+           -e RECREATE_VPN_CRON="0 */6 * * *" \
+           -e NETWORK=192.168.1.0/24 \
+           azinchen/nordvpn-wg
+
+# Applications using VPN (access via host ports)
+docker run -d --name webapp --net=container:vpn \
+           nginx:alpine
+
+docker run -d --name api-service --net=container:vpn \
+           -v ./app:/app -w /app \
+           node:alpine npm start
+```
+
+## Key Points
+
+- **`--cap-add=NET_ADMIN`** and **`--sysctl net.ipv4.conf.all.src_valid_mark=1`** are always required. `/dev/net/tun` and `SYS_ADMIN` are not needed (kernel WireGuard) — see [Permissions](Permissions).
+- **Ports** must be published on the VPN container (`-p` on the `vpn` container), not on the application containers.
+- Application containers connect via `--net=container:vpn`.
+- For GitHub Container Registry, replace `azinchen/nordvpn-wg` with `ghcr.io/azinchen/nordvpn-wg`.

--- a/wiki/FAQ.md
+++ b/wiki/FAQ.md
@@ -1,0 +1,74 @@
+## Credentials
+
+**Q: What credentials do I need?**
+A NordVPN **access token**. Pass it as `TOKEN` and the container reads your account's NordLynx (WireGuard) private key from the NordVPN API. See [Getting a Token](https://github.com/azinchen/nordvpn-wg#getting-a-token).
+
+**Q: Can I use my regular NordVPN email and password?**
+No. You need an access token generated from your Nord Account: [Nord Account Dashboard](https://my.nordaccount.com/) → NordVPN → Manual setup → generate an access token.
+
+**Q: Does the token expire? Is it stored?**
+The token is read at connect time to fetch your WireGuard key from the API; the key itself is never written to disk and is re-fetched on every (re)connect. The WireGuard key is persistent on your account, but the access token has the expiry you chose when generating it — keep it valid (or update `TOKEN` and restart) so reconnects keep working.
+
+## Features
+
+**Q: Which protocol does this use?**
+NordLynx (NordVPN's WireGuard implementation), exclusively. OpenVPN, IKEv2, SOCKS, and HTTP proxy are not supported — use the [OpenVPN variant](https://github.com/azinchen/nordvpn) if you need those.
+
+**Q: Can I use port forwarding / access services from the internet?**
+No. NordVPN does not support inbound port forwarding. You can only access services from your LAN by publishing ports on the VPN container and setting `NETWORK` to include your LAN CIDR.
+
+**Q: How do I know which server I'm connected to?**
+Check the container logs: `docker logs vpn | grep "Selected server"`. Or run the network diagnostic: `docker exec vpn /usr/local/bin/network-diagnostic --basic`.
+
+**Q: Can I connect to a specific server?**
+Yes. Use the server hostname in `COUNTRY` or `CITY`: `-e COUNTRY=es1234` or `-e CITY=uk2567`. Specific servers get priority with `load=0`.
+
+## Networking
+
+**Q: Why can't my app containers reach my LAN?**
+Set `NETWORK` to include your LAN CIDR (e.g., `-e NETWORK=192.168.1.0/24`). Docker subnets and LAN ranges are not auto-allowed. See [Local Network Access](Local-Network-Access).
+
+**Q: Why do I need to publish ports on the VPN container instead of the app container?**
+Containers using `network_mode: "service:vpn"` share the VPN container's network namespace. They don't have their own network stack, so port publishing only works on the VPN container.
+
+**Q: Can I route a whole downstream subnet through the tunnel?**
+Yes — see [VPN Gateway Mode](VPN-Gateway-Mode) and the `FORWARD_FROM` variable.
+
+**Q: Does IPv6 work?**
+The container applies an IPv6 firewall (default DROP), but does not route IPv6 through the VPN. To prevent IPv6 leaks, disable it at the daemon or container level. See [IPv6 Configuration](IPv6-Configuration).
+
+**Q: Why is my torrent client "stalled" even though the swarm has seeds?**
+libtorrent-based clients (qBittorrent, etc.) bind their listen, announce and DHT sockets to the interfaces present at startup. If the client starts before `wg0` is up, those sockets land on `eth0`, where the kill switch blocks them — so the client never discovers peers. Bind the client to the tunnel interface (qBittorrent: Settings → Advanced → Network interface → `wg0`). See [Troubleshooting](Troubleshooting#torrent-client-stalled-despite-a-healthy-swarm).
+
+## Operations
+
+**Q: Why do my app containers lose network after VPN restarts?**
+Containers sharing the VPN's network namespace reference the old namespace after a restart. You must restart them too. See [Updating and Maintenance](Updating-and-Maintenance#why-dependent-containers-must-restart).
+
+**Q: How often should I reconnect?**
+Every 4–8 hours is common. Use `RECREATE_VPN_CRON` for scheduled switching and `CHECK_CONNECTION_CRON` for health monitoring. See [Automatic Reconnection](Automatic-Reconnection).
+
+**Q: What happens if the VPN drops?**
+The kill switch blocks all traffic except `NETWORK` CIDRs and NordVPN API IPs. If health monitoring is configured, the container will automatically reconnect. See [Security Model](Security-Model#traffic-control--kill-switch).
+
+## Compatibility
+
+**Q: Does this work on Raspberry Pi?**
+Yes. The image supports `arm/v6`, `arm/v7`, and `arm64`. Docker pulls the correct architecture automatically. WireGuard support requires a reasonably recent kernel (5.6+ has it built in; older kernels need the `wireguard` module).
+
+**Q: Does this work on Synology / QNAP NAS?**
+Generally yes, but some NAS devices have older kernels or limited iptables/WireGuard support. The container auto-detects nft vs legacy backends. Check logs for `[ENTRYPOINT] Using IPv4 backend:` to verify.
+
+**Q: What's the difference between Docker Hub and GHCR images?**
+They are identical. Use whichever registry is more convenient: `azinchen/nordvpn-wg` (Docker Hub) or `ghcr.io/azinchen/nordvpn-wg` (GitHub Container Registry).
+
+## Logs & Messages
+
+**Q: The log says `VPN connected successfully` but I have no internet. Why?**
+"Connected" means the `wg0` interface came up. If `wg show wg0` reports `0 B received` and no recent handshake, the NordLynx handshake isn't completing — usually a transient server issue or rate-limiting. The scheduled/health reconnect will pick a new server; see [Troubleshooting](Troubleshooting).
+
+**Q: DNS resolution fails inside the container. Why?**
+Docker's embedded resolver (`127.0.0.11`) is unreachable once the kill-switch firewall is applied, so the container writes its own `/etc/resolv.conf` pointing at the VPN DNS servers. If you overrode `DNS` with a server that isn't reachable through the tunnel, resolution will fail. See [Custom DNS](Custom-DNS).
+
+**Q: `CRITICAL: TOKEN is not set` — what's wrong?**
+`TOKEN` is required. Provide a valid NordVPN access token. If you see `could not obtain WireGuard private key from NordVPN API`, the token is invalid or expired.

--- a/wiki/Firewall-Backends.md
+++ b/wiki/Firewall-Backends.md
@@ -1,0 +1,33 @@
+This image ships **both** `iptables` (nft-backed) and `iptables-legacy` (xtables). At runtime, the entrypoint automatically selects a working backend.
+
+## Selection Logic
+
+| Preferred backend | Fallback |
+|-------------------|----------|
+| **nft** (`iptables`) | legacy (`iptables-legacy`) |
+
+The entrypoint probes each backend by toggling a chain policy and prefers nft,
+falling back to legacy only when nft isn't usable in the container's network
+namespace.
+
+## Log Output
+
+When the nft backend is selected:
+```
+[ENTRYPOINT] Kernel: 6.8.0-xx
+[ENTRYPOINT] Using IPv4 backend: iptables
+```
+
+When nft isn't usable and the legacy backend is selected:
+```
+[ENTRYPOINT] Kernel: 6.8.0-xx
+[ENTRYPOINT] Using IPv4 backend: iptables-legacy
+```
+
+## Why This Matters
+
+- Some hosts (especially NAS devices, VMs, or WSL) don't support nftables properly in a container namespace
+- Docker Desktop on macOS/Windows uses a Linux VM whose kernel may behave differently
+- Mixing nft and legacy rules in the same namespace causes unpredictable behavior — the entrypoint prevents this
+
+No manual configuration is needed. The container handles backend selection automatically.

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -1,0 +1,39 @@
+# NordVPN WireGuard Docker Container — Wiki
+
+Welcome to the wiki for the **NordVPN WireGuard Docker Container**. This wiki provides detailed configuration guides, examples, and troubleshooting information beyond what's covered in the [README](https://github.com/azinchen/nordvpn-wg#readme).
+
+> **Looking for OpenVPN?** This has a sibling project, [**azinchen/nordvpn**](https://github.com/azinchen/nordvpn) — the same auto-routing NordVPN container over OpenVPN (including XOR traffic obfuscation). See its [wiki](https://github.com/azinchen/nordvpn/wiki) for OpenVPN-specific guides.
+
+## Getting Started
+
+If you're new, start with the [README](https://github.com/azinchen/nordvpn-wg#readme) for a quick-start guide, then explore the pages below for advanced configuration.
+
+## Pages
+
+### Configuration
+- **[Server Selection](Server-Selection)** — Filter by country, city, group, or specific server hostname
+- **[Server Groups](Server-Groups)** — Specialty server groups: Double VPN, Onion Over VPN, P2P, dedicated IP, and regional filters
+- **[IPv6 Configuration](IPv6-Configuration)** — Prevent IPv6 leaks with daemon, container, or host-level options
+- **[Automatic Reconnection](Automatic-Reconnection)** — Scheduled reconnection, failure handling, and health monitoring
+- **[Local Network Access](Local-Network-Access)** — Allow LAN and inter-container traffic through the firewall
+- **[VPN Gateway Mode](VPN-Gateway-Mode)** — Route other containers' traffic out through the tunnel with `FORWARD_FROM`
+- **[Custom DNS](Custom-DNS)** — Override NordVPN's DNS servers with custom ones (Cloudflare, Google, etc.)
+- **[Permissions](Permissions)** — required capabilities, devices, and sysctls for WireGuard
+
+### Security
+- **[Security Model](Security-Model)** — Kill switch behavior, rule precedence, and network access control
+- **[Firewall Backends](Firewall-Backends)** — How nftables vs iptables-legacy selection works at runtime
+
+### Examples
+- **[Docker Compose Examples](Docker-Compose-Examples)** — Simple, advanced, and web-proxy compose setups
+- **[Docker Run Examples](Docker-Run-Examples)** — Basic and advanced `docker run` usage
+
+### Operations
+- **[Updating and Maintenance](Updating-and-Maintenance)** — How to update the VPN container and restart dependent services
+- **[Troubleshooting](Troubleshooting)** — Common problems, diagnostic tools, and log reading tips
+- **[Network Diagnostics Guide](Network-Diagnostics-Guide)** — Using the built-in diagnostic tool and interpreting output
+
+### Reference
+- **[FAQ](FAQ)** — Frequently asked questions
+- **[Supported Platforms](Supported-Platforms)** — Available architectures and Raspberry Pi notes
+- **[Architecture and Internals](Architecture-and-Internals)** — How the s6-overlay stages, scripts, and firewall work under the hood

--- a/wiki/IPv6-Configuration.md
+++ b/wiki/IPv6-Configuration.md
@@ -1,0 +1,49 @@
+This image **applies an IPv6 firewall** (when `ip6tables` is available and IPv6 is enabled): `INPUT`/`FORWARD`/`OUTPUT` default to `DROP`. It does **not** change IPv6 sysctls from inside the container (many environments mount `/proc/sys` read-only).
+
+If your Docker runtime assigns IPv6 addresses and you want to avoid IPv6 leaks, choose **one** of the following options.
+
+## Option A — Disable IPv6 for the Docker daemon/network (recommended)
+
+- **Daemon-wide:** set `"ipv6": false` in Docker's `daemon.json` and restart Docker.
+- **Per-network:** create the network with `--ipv6=false`.
+
+## Option B — Disable IPv6 per container via runtime sysctls
+
+Pass sysctls at **run** time (works even when `/proc/sys` is read-only inside the container):
+
+```bash
+docker run -d --cap-add=NET_ADMIN --name vpn \
+           --sysctl net.ipv4.conf.all.src_valid_mark=1 \
+           --sysctl net.ipv6.conf.all.disable_ipv6=1 \
+           --sysctl net.ipv6.conf.default.disable_ipv6=1 \
+           --sysctl net.ipv6.conf.eth0.disable_ipv6=1 \
+           azinchen/nordvpn-wg
+```
+
+**docker-compose:**
+
+```yaml
+services:
+  vpn:
+    image: azinchen/nordvpn-wg
+    sysctls:
+      net.ipv6.conf.all.disable_ipv6: "1"
+      net.ipv6.conf.default.disable_ipv6: "1"
+      net.ipv6.conf.eth0.disable_ipv6: "1"
+```
+
+## Option C — Disable IPv6 on the host
+
+Use host sysctls or OS network settings to turn off IPv6 globally.
+
+## How to Verify IPv6 Is Off
+
+Inside the container:
+
+```bash
+cat /proc/net/if_inet6            # no output means no IPv6 addresses
+ip -6 addr show dev eth0          # should show "Device not found" or no inet6 lines
+ip6tables -S 2>/dev/null || true  # may be empty/unavailable
+```
+
+> **Note:** If your environment leaves IPv6 **enabled**, IPv6 traffic may bypass the IPv4 firewall. Use one of the options above to disable IPv6 at runtime.

--- a/wiki/Local-Network-Access.md
+++ b/wiki/Local-Network-Access.md
@@ -1,0 +1,78 @@
+By default, all traffic is routed through the VPN. To allow access to local services, your LAN, or inter-container networks, you must explicitly define them with the `NETWORK` variable.
+
+## Finding Your Local Network
+
+```bash
+ip route | awk '!/ (docker0|br-)/ && /src/ {print $1}'
+```
+
+## Configuration
+
+```bash
+docker run -d --cap-add=NET_ADMIN \
+           --sysctl net.ipv4.conf.all.src_valid_mark=1 \
+           -e NETWORK=192.168.1.0/24 \
+           -e TOKEN=your_nordvpn_token_here \
+           azinchen/nordvpn-wg
+```
+
+Multiple CIDRs are semicolon-separated:
+
+```bash
+-e NETWORK="192.168.1.0/24;172.20.0.0/16;10.0.0.0/8"
+```
+
+## What `NETWORK` Does
+
+When `NETWORK` is set, the `init-firewall` script:
+
+1. Adds a **static route** for each CIDR via the default gateway (so traffic bypasses the VPN tunnel)
+2. Adds **bidirectional iptables rules** allowing traffic to/from those CIDRs
+3. These rules apply **regardless of VPN state** — they remain active even if the VPN drops
+
+## Important Notes
+
+- **Docker subnets are NOT auto-allowed.** If containers sharing the VPN namespace need to talk to each other or to services on your LAN/host, include those CIDRs in `NETWORK`.
+- **Only CIDRs (IP ranges) are supported**, not domain names.
+- **Keep `NETWORK` as narrow as possible.** Broad CIDRs weaken the kill switch since traffic to those destinations is always allowed.
+
+## Common Scenarios
+
+### Access services on your LAN
+```bash
+-e NETWORK=192.168.1.0/24
+```
+
+### Allow Docker inter-container communication
+```bash
+-e NETWORK="192.168.1.0/24;172.20.0.0/16"
+```
+
+### Multiple network segments
+```bash
+-e NETWORK="10.0.0.0/8;172.16.0.0/12;192.168.0.0/16"
+```
+
+## Docker Compose Example
+
+```yaml
+services:
+  vpn:
+    image: azinchen/nordvpn-wg:latest
+    cap_add:
+      - NET_ADMIN
+    sysctls:
+      - net.ipv4.conf.all.src_valid_mark=1
+    environment:
+      - TOKEN=your_nordvpn_token_here
+      - NETWORK=192.168.1.0/24;172.20.0.0/16
+    ports:
+      - "8080:8080"
+    restart: unless-stopped
+
+  app:
+    image: nginx:alpine
+    network_mode: "service:vpn"
+    depends_on:
+      - vpn
+```

--- a/wiki/Network-Diagnostics-Guide.md
+++ b/wiki/Network-Diagnostics-Guide.md
@@ -1,0 +1,100 @@
+The container includes a built-in diagnostic tool at `/usr/local/bin/network-diagnostic` that provides comprehensive network and VPN status information for a WireGuard-connected system.
+
+## Running Diagnostics
+
+### Automatic (on every connection)
+
+```bash
+-e NETWORK_DIAGNOSTIC_ENABLED=true
+```
+
+### Manual
+
+```bash
+# Full diagnostics
+docker exec vpn /usr/local/bin/network-diagnostic
+
+# Quick IP + location check only
+docker exec vpn /usr/local/bin/network-diagnostic --basic
+```
+
+## Modes
+
+### `--basic` Mode
+
+Outputs a single line:
+
+```
+Public IP address 203.0.113.42, location Amsterdam NL
+```
+
+Returns exit code 0 on success, 1 if the public IP couldn't be determined.
+
+### `--full` Mode (default)
+
+Produces a comprehensive report covering all sections below.
+
+## Output Sections (Full Mode)
+
+### Header & VPN Status
+
+```
+WireGuard DIAG (full) : 2026-03-22T16:30:00+00:00
+VPN Status            : CONNECTED
+```
+
+VPN status is derived from the `wg0` interface and its peer endpoint.
+
+### WireGuard & Connection Info
+
+- `### ip addr show wg0` — tunnel interface address
+- `### wg show` — peer public key, endpoint, last handshake, transfer counters, listening port
+- `### wg0.conf` — the generated config (private key redacted in logs)
+
+The peer endpoint reported by `wg show` is the VPN server you're connected to.
+
+### System Network State
+
+- `### ip link (up)` — link states
+- `### ip route (main)` — main routing table
+- `### ip rule` — policy routing rules (WireGuard installs an fwmark rule)
+- `### ip route table 51820` — the WireGuard routing table (default via wg0)
+- `### ip route get <test IP>` — which interface a packet to the internet uses (should be wg0)
+
+### Firewall Rules
+
+- `### iptables -S (filter)` and `### iptables -t nat -S` — IPv4 rules
+- `### ip6tables -S` / nat — IPv6 rules (if available)
+- Detects whether nft or legacy backend is in use
+
+### Public IP & Geolocation
+
+- `### Public IP / Geo (best-effort)` — JSON from an IP lookup service (IP, city, country, ISP/org). This is what confirms which exit node you're using.
+
+### DNS
+
+- `### DNS configuration` — contents of `/etc/resolv.conf`
+- `### DNS servers geolocation` — geolocation lookup for each nameserver
+- `### resolver identity via <ns>` — identity probe of the active resolver
+
+### Connectivity Tests
+
+- `### Ping checks` — IPv4/IPv6 reachability
+- `### Short trace to <test IP>` — first hop should be the VPN
+- `### Quick verdicts` — summary checks
+
+## IP Resolution Fallback
+
+The diagnostic tool uses a fallback to determine your public IP from more than one service, each with a short timeout, so a single slow/unreachable provider doesn't block the report.
+
+## Using Diagnostics for Troubleshooting
+
+| Symptom | What to check in diagnostic output |
+|---------|------|
+| Wrong country | Public IP / Geo — confirms which exit you're using |
+| DNS leaks | DNS configuration / geolocation — nameservers should be VPN-provided |
+| No connectivity | `wg show` — confirm a recent handshake and non-zero received bytes |
+| Traffic not tunneled | `ip route get` — should resolve via `wg0` |
+| Firewall issues | iptables dump — look for missing ACCEPT rules on wg0 |
+
+See also: [Troubleshooting](Troubleshooting)

--- a/wiki/Permissions.md
+++ b/wiki/Permissions.md
@@ -1,0 +1,44 @@
+WireGuard's `wg-quick` needs root and specific kernel capabilities to create the tunnel interface and program routing/firewall rules. This container therefore runs its processes as **root** inside the container (there is no privilege-dropping process user, unlike the OpenVPN variant).
+
+## Required Capabilities & Devices
+
+| Requirement | Why |
+|-------------|-----|
+| `--cap-add=NET_ADMIN` | Create/configure the `wg0` interface, policy routing, and iptables rules |
+| `--sysctl net.ipv4.conf.all.src_valid_mark=1` | Required for WireGuard's reverse-path / fwmark routing. `wg-quick` tries to set this itself but can't inside a container (read-only `/proc/sys`), so it must be passed in — otherwise the tunnel fails to come up. |
+
+That's all that's needed. The image uses **kernel** WireGuard (it ships only `wireguard-tools`, no userspace backend), so:
+
+- **`/dev/net/tun` is not required** — TUN is only used by userspace WireGuard implementations (wireguard-go/boringtun).
+- **`SYS_ADMIN` is not required** — passing the sysctl above via Docker removes the only reason `wg-quick` would have needed it.
+
+The trade-off is that the host kernel must provide WireGuard (5.6+ built in, or the `wireguard` module loaded) — there is no userspace fallback. If your host blocks sysctl changes entirely, `privileged: true` works as a last resort.
+
+### Docker Compose
+
+```yaml
+services:
+  vpn:
+    image: azinchen/nordvpn-wg:latest
+    cap_add:
+      - NET_ADMIN
+    sysctls:
+      - net.ipv4.conf.all.src_valid_mark=1
+    environment:
+      - TOKEN=your_nordvpn_token_here
+```
+
+### Docker Run
+
+```bash
+docker run -d --cap-add=NET_ADMIN \
+           --sysctl net.ipv4.conf.all.src_valid_mark=1 \
+           -e TOKEN=your_nordvpn_token_here \
+           azinchen/nordvpn-wg
+```
+
+## Volume Permissions
+
+This container does not create a separate process user and does not take `PUID`/`PGID`.
+Containers that share the VPN's network namespace manage their own volume permissions
+independently.

--- a/wiki/Security-Model.md
+++ b/wiki/Security-Model.md
@@ -1,0 +1,40 @@
+This page describes the container's firewall behavior, kill switch, and network access control in detail.
+
+## Traffic Control & Kill Switch
+
+- **Default-deny (egress):** All outbound traffic is blocked unless it goes through the VPN interface, matches `NETWORK` (CIDRs you define), or is directed to NordVPN's API.
+- **Bootstrap (pre-VPN):** DNS egress is **blocked**. The container contacts NordVPN's API via **pinned IP addresses** from `NORDVPNAPI_IP` to select a server (no DNS queries before the tunnel is up).
+- **Kill switch:** If the VPN drops, traffic remains blocked **except** for destinations within your `NETWORK` CIDRs (e.g., local/LAN ranges you explicitly allowed) and to NordVPN's API.
+- **Container routing:** Containers using `network_mode: "service:vpn"` share the VPN container's network namespace and inherit these policies.
+- **Inbound (local/LAN only):** No connections from the host or LAN reach the stack **unless you publish ports on the VPN container**. **Public inbound via NordVPN is not supported** (no port forwarding).
+
+## Network Access Control (Exceptions)
+
+- **Local/LAN access (bidirectional, explicit):** Set `NETWORK=192.168.1.0/24` (semicolon-separated CIDRs supported) to allow access to those subnets **regardless of VPN status**.
+- **No domain names allowed:** Use IPs in `NETWORK` for any non-VPN access you require.
+
+## Rule Precedence
+
+1. **Bootstrap-only (when VPN is down & before first connect):** Allow HTTPS only to the **NordVPN API IPs from `NORDVPNAPI_IP`** used by the image's bootstrap script.
+2. **Exceptions:** If destination matches `NETWORK` (CIDR), allow (bypass/LAN), regardless of VPN state.
+3. **VPN path:** If VPN is **up** and traffic is not an exception, allow only via the VPN interface.
+4. **Default-deny:** Otherwise, block.
+
+## Security Notes
+
+### Kill Switch Limitations
+
+Because `NETWORK` remains open when the VPN is down, this is **not a strict kill switch** if you include broad CIDRs. Keep `NETWORK` as narrow as possible (e.g., just your LAN / management subnets).
+
+**Warning:** Setting `NETWORK=0.0.0.0/0` effectively disables the kill switch entirely — all traffic will bypass the VPN.
+
+### Token Exposure
+
+The NordVPN access token passed via the `TOKEN` environment variable is:
+- Visible via `docker inspect` on the container
+- Visible in the process environment
+
+The token is used only to fetch your WireGuard key from the NordVPN API; it is never written to the WireGuard config. Still, to reduce exposure:
+- Use a `.env` file with `env_file:` in Docker Compose (keeps the token out of `docker-compose.yml`)
+- Avoid passing the token directly on the `docker run` command line (visible in process listings)
+- Generate the token with a sensible expiry and rotate it if it may have leaked

--- a/wiki/Server-Groups.md
+++ b/wiki/Server-Groups.md
@@ -1,0 +1,157 @@
+The `GROUP` environment variable filters the NordVPN server fleet by specialty. Each group is a separate set of servers with different capabilities. Only **one** group can be set at a time.
+
+> **NordLynx only:** this container connects with NordLynx (WireGuard). Server lookups are always filtered to NordLynx-capable servers. Groups that historically exist only for OpenVPN (e.g. **Obfuscated / XOR**) have no NordLynx servers — selecting them returns nothing and the container falls back to the recommended pool.
+
+## Quick Reference
+
+| Group | Identifier | Availability |
+|-------|-----------|--------------|
+| Standard VPN servers | `legacy_standard` | All countries |
+| P2P | `legacy_p2p` | Most countries |
+| Double VPN | `legacy_double_vpn` | Limited country pairs |
+| Onion Over VPN | `legacy_onion_over_vpn` | Very limited (NL, SE, CH) |
+| Dedicated IP | `legacy_dedicated_ip` | Subscription-dependent |
+| Anti DDoS | `legacy_anti_ddos` | Limited |
+| Europe | `europe` | Regional |
+| The Americas | `the_americas` | Regional |
+| Asia Pacific | `asia_pacific` | Regional |
+| Africa, the Middle East and India | `africa_the_middle_east_and_india` | Regional |
+
+You can also use the human-readable names (e.g., `GROUP=Double VPN`) or numeric IDs. The full list is in [GROUPS.md](https://github.com/azinchen/nordvpn-wg/blob/main/GROUPS.md).
+
+When `GROUP` is not set, the API returns servers from the default recommended pool (equivalent to `legacy_standard`).
+
+## Standard VPN Servers (`legacy_standard`)
+
+The default NordVPN fleet. General-purpose servers suitable for everyday use.
+
+```yaml
+environment:
+  # GROUP not needed — this is the default
+  - COUNTRY=United States
+```
+
+Available in all countries and cities. This is what you get when `GROUP` is omitted.
+
+## P2P (`legacy_p2p`)
+
+Servers optimized for peer-to-peer traffic. These allow the incoming connections that BitTorrent and other P2P protocols require.
+
+```yaml
+environment:
+  - GROUP=legacy_p2p
+  - COUNTRY=Netherlands
+```
+
+Use when torrenting or file sharing. Available in most countries, though some countries where P2P is restricted by law may not have P2P servers.
+
+## Double VPN (`legacy_double_vpn`)
+
+Traffic is routed through two VPN servers in different countries. Availability of NordLynx Double VPN servers is limited — if none are returned, the container falls back to the recommended pool.
+
+```yaml
+environment:
+  - GROUP=legacy_double_vpn
+```
+
+Server names show both countries (e.g., `ca-us75` = Canada entry → United States exit). You can filter by `COUNTRY` to select the exit country, but only pre-defined country pairs are available.
+
+### Trade-offs
+
+- Higher latency than standard servers (traffic traverses two hops)
+- Lower throughput
+- Not compatible with P2P traffic
+
+## Onion Over VPN (`legacy_onion_over_vpn`)
+
+The VPN server routes your outbound traffic into the Tor network. No local Tor client is needed. Available in very few locations (Netherlands, Sweden, Switzerland at time of writing).
+
+```yaml
+environment:
+  - GROUP=legacy_onion_over_vpn
+```
+
+### Important: DNS configuration
+
+**Do not override DNS** when using Onion Over VPN. The default NordVPN DNS servers (`103.86.96.100`, `103.86.99.100`) route DNS queries through the Tor network. If you set `DNS` to external resolvers (e.g., Cloudflare `1.1.1.1`), DNS queries will fail because Tor only carries TCP traffic and standard DNS uses UDP.
+
+### Trade-offs
+
+- Significantly slower than standard or Double VPN (Tor adds multiple hops)
+- Not compatible with P2P traffic
+- Some websites block Tor exit nodes
+
+## Dedicated IP (`legacy_dedicated_ip`)
+
+For NordVPN accounts with the [Dedicated IP add-on](https://nordvpn.com/features/dedicated-ip/). Provides a static IP address assigned exclusively to your account.
+
+```yaml
+environment:
+  - GROUP=legacy_dedicated_ip
+```
+
+The API returns Dedicated IP servers regardless of your subscription status, but you need an active Dedicated IP add-on on your NordVPN account to successfully use these servers.
+
+### When to use
+
+- IP whitelisting for remote access
+- Services that block shared VPN IP addresses
+- When you need a consistent public IP
+
+## Anti DDoS (`legacy_anti_ddos`)
+
+Servers with DDoS protection.
+
+```yaml
+environment:
+  - GROUP=legacy_anti_ddos
+```
+
+Useful for gaming or hosting services exposed through the VPN. This group may have limited server availability.
+
+## Regional Groups
+
+Broad geographic filters that return servers from an entire region rather than a specific country.
+
+| Group | Identifier |
+|-------|-----------|
+| Europe | `europe` |
+| The Americas | `the_americas` |
+| Asia Pacific | `asia_pacific` |
+| Africa, the Middle East and India | `africa_the_middle_east_and_india` |
+
+```yaml
+environment:
+  - GROUP=europe
+  - RANDOM_TOP=10
+```
+
+Use when you don't need a specific country — just a region.
+
+## Combining with Other Parameters
+
+`GROUP` is sent to the NordVPN API as an AND filter alongside other parameters. All filters must match for a server to be returned.
+
+| Parameter | Combines with `GROUP`? | Notes |
+|-----------|----------------------|-------|
+| `COUNTRY` | Yes | Servers must match both group and country |
+| `CITY` | Yes | Servers must match both group and city |
+| `RANDOM_TOP` | Yes | Applied after filtering — picks randomly from top N results |
+
+### Restrictions
+
+- **One group at a time.** The API accepts a single group filter. You cannot combine `legacy_p2p` with `legacy_double_vpn`, for example.
+- **NordLynx availability.** Groups without NordLynx servers (e.g. Obfuscated/XOR) return nothing.
+- **Empty results.** If the combination of `GROUP` + `COUNTRY` + `CITY` has no matching servers, the container falls back to default recommended servers (without the group filter).
+
+## Legacy and Internal Groups
+
+The NordVPN API also lists groups that are **not useful** for this container:
+
+| Group | Reason |
+|-------|--------|
+| `legacy_obfuscated_servers` | XOR obfuscation — OpenVPN only, no NordLynx servers |
+| `legacy_ultra_fast_tv` (ID 5) | Legacy streaming group — few or no servers |
+| `legacy_netflix_usa` (ID 13) | Legacy streaming group — few or no servers |
+| `legacy_socks5_proxy` (ID 245) | SOCKS5 protocol — not supported by this container |
+| `anycast-dns`, `geo_dns`, `grafana`, `kapacitor`, `fastnetmon` | NordVPN internal infrastructure |

--- a/wiki/Server-Selection.md
+++ b/wiki/Server-Selection.md
@@ -1,0 +1,62 @@
+Filter NordVPN servers using location and server criteria.
+
+## Example
+
+```bash
+docker run -d --cap-add=NET_ADMIN \
+           --sysctl net.ipv4.conf.all.src_valid_mark=1 \
+           -e TOKEN=your_nordvpn_token_here \
+           -e COUNTRY="United States;CA;153" \
+           -e CITY="New York;2619989;es1234" \
+           -e GROUP="Standard VPN servers" \
+           -e RANDOM_TOP=5 \
+           azinchen/nordvpn-wg
+```
+
+## Location Specification
+
+| Filter | Accepted formats | Examples |
+|--------|-----------------|----------|
+| **COUNTRY** | Name, 2-letter code, or numeric ID | `United States`, `US`, `228` |
+| **CITY** | Name or numeric ID | `New York`, `8971718` |
+| **Specific server** | Hostname (in COUNTRY or CITY) | `es1234`, `uk2567` |
+
+Multiple values are semicolon-separated: `COUNTRY="United States;CA;228"`
+
+### Specific Server Hostname Format
+
+To connect to a specific NordVPN server, use its short hostname. The format is:
+
+```
+<2-letter country code><server number>
+```
+
+**Pattern:** Exactly 2 letters followed by 1 or more digits (case-insensitive).
+
+| Input | Resolved hostname | How it works |
+|-------|------------------|---------------|
+| `us1` | `us1.nordvpn.com` | US server #1 |
+| `DE456` | `de456.nordvpn.com` | Germany server #456 |
+| `gb42` | `gb42.nordvpn.com` | UK server #42 |
+
+Specific servers are:
+- Looked up by hostname against the NordVPN API for their WireGuard endpoint and public key
+- Given `load=0` so they always appear first in the server list
+- Placed in either `COUNTRY` or `CITY` — both work the same way
+
+**Invalid formats** (will be treated as country/city names): `usa1` (3 letters), `u1` (1 letter), `us` (no digits).
+
+Reference lists:
+- [Countries](https://github.com/azinchen/nordvpn-wg/blob/main/COUNTRIES.md)
+- [Cities](https://github.com/azinchen/nordvpn-wg/blob/main/CITIES.md)
+- [Groups](https://github.com/azinchen/nordvpn-wg/blob/main/GROUPS.md)
+
+## Selection Behavior
+
+- **Specific servers** (e.g., `es1234`): Placed at the top of the list with `load=0`
+- **Multiple locations**: Combined and sorted by server load (lowest first)
+- **Single location**: Keeps NordVPN's recommended order
+- **RANDOM_TOP=N**: After filtering and sorting, randomly picks from the top N servers
+
+All server lookups are filtered to NordVPN's NordLynx (WireGuard) technology. Cities are
+resolved to their NordVPN city ID and queried via the `country_city_id` API filter.

--- a/wiki/Supported-Platforms.md
+++ b/wiki/Supported-Platforms.md
@@ -1,0 +1,34 @@
+This image supports multiple CPU architectures. Docker will automatically pull the correct image for your platform.
+
+## Available Architectures
+
+| Architecture | Platform |
+|--------------|----------|
+| `386` | 32-bit x86 |
+| `amd64` | 64-bit x86 |
+| `arm/v6` | ARM v6 |
+| `arm/v7` | ARM v7 (Raspberry Pi 2/3) |
+| `arm64` | 64-bit ARM (Raspberry Pi 4/5, Apple M1) |
+| `ppc64le` | PowerPC 64-bit LE (IBM Power) |
+| `s390x` | IBM System z |
+| `riscv64` | 64-bit RISC-V |
+
+## Automatic Architecture Detection
+
+When you run `docker pull azinchen/nordvpn-wg`, Docker automatically detects your system's architecture and pulls the appropriate image variant. No manual selection is required.
+
+## Verifying Your Architecture
+
+To check which architecture Docker is using:
+
+```bash
+docker image inspect azinchen/nordvpn-wg:latest --format '{{.Architecture}}'
+```
+
+## Raspberry Pi Notes
+
+- **Raspberry Pi 2/3**: Uses `arm/v7`
+- **Raspberry Pi 4/5**: Uses `arm64` (recommended) or `arm/v7`
+- **Raspberry Pi Zero/1**: Uses `arm/v6`
+
+For best performance on Raspberry Pi 4 and newer, ensure you're running a 64-bit OS to take advantage of the `arm64` image.

--- a/wiki/Troubleshooting.md
+++ b/wiki/Troubleshooting.md
@@ -1,0 +1,147 @@
+## Connection Problems
+
+### VPN won't connect
+
+**Symptoms:** Container starts but the tunnel never comes up, or it crash-loops.
+
+**Check:**
+1. **Token:** Verify `TOKEN` is a valid, unexpired NordVPN access token. `CRITICAL: TOKEN is not set` or `could not obtain WireGuard private key from NordVPN API` means the token is missing/invalid. See [Getting a Token](https://github.com/azinchen/nordvpn-wg#getting-a-token).
+2. **Logs:** `docker logs vpn` — look for the `[VPN-CONFIG]` and `[SERVICE-NORDVPN]` lines.
+3. **API access:** The container needs HTTPS access to NordVPN API IPs during bootstrap. Behind a corporate proxy/firewall, ensure TCP/443 to the `NORDVPNAPI_IP` addresses is allowed.
+4. **Kernel WireGuard:** The image uses the host's kernel WireGuard module (no userspace fallback, so `/dev/net/tun` is not needed). Ensure the host kernel is 5.6+ or has the `wireguard` module loaded.
+5. **Capabilities:** WireGuard needs `NET_ADMIN` plus the `net.ipv4.conf.all.src_valid_mark=1` sysctl (or `privileged: true`) so `wg-quick` can set its routing policy. `SYS_ADMIN` is not required.
+
+### `VPN connected successfully` but no traffic
+
+**Symptoms:** `wg0` exists but nothing flows.
+
+**Check:**
+1. **Handshake:** `docker exec vpn wg show wg0`. If you see `0 B received` and no `latest handshake`, the NordLynx handshake isn't completing — usually a transient/overloaded server or rate-limiting. Wait for the health/scheduled reconnect, or restart to pick a new server.
+2. **Firewall:** `docker exec vpn iptables -S OUTPUT` — verify the `-o wg0 -j ACCEPT` rule exists.
+3. **Diagnostics:** `docker exec vpn /usr/local/bin/network-diagnostic`
+
+### Connection drops frequently
+
+**Fix:** Use health monitoring and scheduled switching:
+```yaml
+environment:
+  - CHECK_CONNECTION_CRON=*/5 * * * *
+  - CHECK_CONNECTION_URL=https://1.1.1.1
+  - RECREATE_VPN_CRON=0 */6 * * *
+```
+
+See [Automatic Reconnection](Automatic-Reconnection#connection-health-monitoring) for details.
+
+## Networking Problems
+
+### Containers behind VPN have no network
+
+**Symptoms:** `docker exec app curl https://example.com` fails.
+
+**Check:**
+1. **VPN is up:** `docker exec vpn wg show wg0` — confirm a recent handshake.
+2. **DNS:** `docker exec vpn cat /etc/resolv.conf` — should list the VPN DNS servers the container wrote (default `103.86.96.100` / `103.86.99.100`, or your `DNS` override). See [Custom DNS](Custom-DNS).
+3. **Firewall:** `docker exec vpn iptables -S` — verify the OUTPUT chain allows traffic via wg0.
+
+### Can't access containers from LAN
+
+**Fix:** Set `NETWORK` to include your LAN CIDR:
+```bash
+-e NETWORK=192.168.1.0/24
+```
+
+Docker subnets are **not** auto-allowed. If inter-container communication is needed, include Docker's subnet too.
+
+### Torrent client stalled despite a healthy swarm
+
+**Symptoms:** qBittorrent (or another libtorrent-based client) running with `network_mode: "service:vpn"` shows torrents as **stalled** with 0 peers, while the swarm has plenty of seeds. Ordinary outbound traffic from the namespace (e.g. `curl`) works fine.
+
+**Cause:** libtorrent binds its listen sockets — including DHT and the per-socket tracker announces — to the interfaces that exist **when the client starts**. If the client comes up before `wg0` does (typical: both containers start together and WireGuard needs a few seconds), it binds only `lo` and `eth0`. Tracker announces and DHT queries from the `eth0`-bound sockets are blocked by the kill switch (by design), so the client never discovers any peers — even though unbound outgoing connections still route through the tunnel. The `RECREATE_VPN_CRON` interface swap has the same effect on a previously working binding.
+
+**Fix:** Bind the client explicitly to the tunnel interface. In qBittorrent: **Settings → Advanced → Network interface → `wg0`** (stored as `Session\Interface=wg0`, or set `current_network_interface=wg0` via the WebUI API). libtorrent tracks the interface by name and re-binds automatically each time `wg0` is recreated on reconnect.
+
+**Verify:** inside the namespace, `netstat -tln | grep 6881` should show the listen socket on the wg0 address (e.g. `10.5.0.2:6881`); then force a reannounce and peers should appear.
+
+### DNS leaks
+
+**Check:**
+1. Run diagnostics: `docker exec vpn /usr/local/bin/network-diagnostic`
+2. Look at the DNS section — nameservers should be VPN-provided addresses, reached over `wg0`
+3. If using IPv6, it may bypass the VPN. See [IPv6 Configuration](IPv6-Configuration)
+
+### NETWORK setting defeats the kill switch
+
+**Cause:** `NETWORK` CIDRs are always allowed, regardless of VPN state. If you set `NETWORK=0.0.0.0/0`, **all traffic bypasses the VPN**.
+
+**Fix:** Keep `NETWORK` as narrow as possible — only include your LAN subnet and any Docker networks that need direct access.
+
+## Firewall & Permissions
+
+### iptables errors on container start
+
+**Symptoms:** Errors like `iptables: No chain/target/match by that name` or `Permission denied`.
+
+**Check:**
+1. **NET_ADMIN capability:** Ensure `--cap-add=NET_ADMIN` is set.
+2. **Kernel compatibility:** The container auto-detects nft vs legacy. Check logs for `[ENTRYPOINT] Using IPv4 backend:` to see which was selected.
+3. **Host iptables/WireGuard modules:** Some minimal hosts (e.g., certain NAS devices) may lack required kernel modules.
+
+### `wg-quick` fails to set routing / `src_valid_mark`
+
+Pass the `net.ipv4.conf.all.src_valid_mark=1` sysctl (or run `privileged: true`). `wg-quick` tries to set this itself but can't inside a container with a read-only `/proc/sys`, so Docker must set it. See the compose snippet in [Docker Compose Examples](Docker-Compose-Examples).
+
+## Scheduling
+
+### Cron jobs not running
+
+**Check:**
+1. **Syntax:** Valid cron format (5 fields). Invalid expressions are silently ignored by crond.
+2. **Logs:** Look for `[INIT-SETUPCRON]` lines at startup — they show the parsed schedule in human-readable format.
+3. **Crontab:** `docker exec vpn cat /var/spool/cron/crontabs/root`
+
+## Diagnostics
+
+### Built-in Network Diagnostics
+
+Enable automatic diagnostics on every VPN connection:
+
+```bash
+-e NETWORK_DIAGNOSTIC_ENABLED=true
+```
+
+Or run manually:
+
+```bash
+docker exec vpn /usr/local/bin/network-diagnostic          # full diagnostics
+docker exec vpn /usr/local/bin/network-diagnostic --basic   # IP + location only
+```
+
+The diagnostic tool checks: public IP and geolocation, WireGuard status, network interfaces, firewall rules, DNS nameservers, IP routing table, and kernel version.
+
+### Reading Container Logs
+
+```bash
+docker logs vpn              # full logs
+docker logs -f vpn           # follow in real-time
+docker logs --tail 50 vpn    # last 50 lines
+```
+
+Key log messages:
+
+| Log message | Meaning |
+|------------|---------|
+| `[ENTRYPOINT] Using IPv4 backend: ...` | Firewall backend selected |
+| `[VPN-CONFIG] Selected server ...` | Selected VPN server |
+| `[SERVICE-NORDVPN] VPN connected successfully` | `wg0` came up (verify with a handshake) |
+| `[SERVICE-NORDVPN] VPN connection timeout` | Tunnel didn't establish in time |
+| `[HEALTHCHECK] Connection check failed` | Health check triggered reconnection |
+
+### Inspecting the Container
+
+```bash
+docker exec vpn wg show wg0                  # WireGuard peer/handshake/transfer
+docker exec vpn ip route                     # view routing table
+docker exec vpn iptables -S                   # check iptables rules
+docker exec vpn cat /etc/resolv.conf          # active DNS servers
+docker exec vpn env | sort                    # check environment
+```

--- a/wiki/Updating-and-Maintenance.md
+++ b/wiki/Updating-and-Maintenance.md
@@ -1,0 +1,26 @@
+When the `vpn` container is restarted — whether due to an image update or a manual restart — every container that uses `network_mode: "service:vpn"` must also be restarted so they reattach to the recreated network namespace.
+
+## With Docker Compose
+
+```bash
+docker compose pull
+docker compose up -d --force-recreate
+```
+
+## With Plain Docker (no Compose)
+
+```bash
+docker pull azinchen/nordvpn-wg:latest   # or ghcr.io/azinchen/nordvpn-wg:latest
+docker stop vpn && docker rm vpn
+# Re-run your "vpn" container with the same args as before...
+# Then restart each dependent container:
+docker restart webapp api-service redis
+```
+
+## Safer Automated Updates for Compose Stacks
+
+Consider using [azinchen/update-docker-containers](https://github.com/azinchen/update-docker-containers) for automated, safe container updates.
+
+## Why Dependent Containers Must Restart
+
+Containers that use `network_mode: "service:vpn"` share the VPN container's network namespace. When the VPN container is recreated, a new namespace is created. Dependent containers still reference the old (now dead) namespace and lose all network connectivity until they are restarted.

--- a/wiki/VPN-Gateway-Mode.md
+++ b/wiki/VPN-Gateway-Mode.md
@@ -1,0 +1,108 @@
+By default the container only routes **its own** traffic (and that of containers sharing its network namespace) through the VPN. **Gateway mode** lets the container act as a router for *other* containers that keep their own network namespace — for example a VPN server (ocserv, WireGuard, SoftEther…) whose clients should exit through NordVPN.
+
+This is the opposite of [`NETWORK`](Local-Network-Access): `NETWORK` lets traffic **bypass** the tunnel to reach your LAN, while `FORWARD_FROM` lets downstream traffic **route out through** the tunnel.
+
+## What `FORWARD_FROM` Does
+
+When `FORWARD_FROM` is set, the `init-firewall` script, for each CIDR:
+
+1. Adds `FORWARD -s <cidr> -o wg0 -j ACCEPT` — lets that subnet's traffic leave through the tunnel.
+2. Adds the matching `wg0 → <cidr>` `ESTABLISHED,RELATED` return rule.
+
+The existing `POSTROUTING -o wg0 -j MASQUERADE` rule then NATs the forwarded packets onto the tunnel, so no extra NAT is needed.
+
+Only the **`FORWARD`** chain is opened — `INPUT`/`OUTPUT` stay locked by the kill switch, and the rules reference `wg0`. If the tunnel drops, they cannot match, so **downstream traffic is dropped rather than leaked**.
+
+## Requirements
+
+- **The usual gateway capabilities:** `--cap-add=NET_ADMIN` and `--sysctl net.ipv4.conf.all.src_valid_mark=1` (the standard requirements — see [Permissions](Permissions); `SYS_ADMIN` and `/dev/net/tun` are not needed).
+- **Enable IPv4 forwarding** on the container: `--sysctl net.ipv4.ip_forward=1`.
+- **Downstream traffic must arrive already SNATed** into one of the `FORWARD_FROM` CIDRs (i.e. masqueraded to the downstream container's address on the shared docker network). That way the gateway needs **no return route** to the downstream client subnet — replies come back to an address it already knows.
+
+## Multiple Subnets
+
+`FORWARD_FROM` is semicolon- or comma-separated, just like `NETWORK`:
+
+```bash
+-e FORWARD_FROM="172.28.0.0/24;10.30.0.0/24;192.168.50.0/24"
+```
+
+## Docker Compose Example: ocserv (OpenConnect) server
+
+This routes an [ocserv](https://github.com/azinchen/ocserv-server) OpenConnect/AnyConnect server's clients out through NordVPN. The `azinchen/ocserv-server` image takes a **`VPN_GATEWAY`** variable, so it SNATs its own VPN clients into the shared docker network and policy-routes them to the gateway for you — no manual `ip route`/`ip rule` needed on the downstream container.
+
+```yaml
+networks:
+  ocservnet:
+    ipam:
+      config:
+        - subnet: 172.20.0.0/24
+
+services:
+  vpn:
+    image: azinchen/nordvpn-wg:latest
+    container_name: ocserv-nordvpn
+    cap_add:
+      - NET_ADMIN                            # only capability the gateway needs
+    sysctls:
+      - net.ipv4.ip_forward=1                # required: forward downstream traffic
+      - net.ipv4.conf.all.src_valid_mark=1   # required by WireGuard
+      - net.ipv6.conf.all.disable_ipv6=1     # optional: avoid IPv6 leaks
+    environment:
+      - TOKEN=your_nordvpn_token_here
+      - CITY=New York
+      - RANDOM_TOP=10
+      - RECREATE_VPN_CRON=0 */3 * * *
+      - FORWARD_FROM=172.20.0.0/24           # the docker net ocserv SNATs into
+    networks:
+      ocservnet:
+        ipv4_address: 172.20.0.2             # static, so ocserv can route to it
+    restart: unless-stopped
+
+  ocserv:
+    image: azinchen/ocserv-server:latest
+    container_name: ocserv-server
+    depends_on:
+      - vpn
+    cap_add:
+      - NET_ADMIN
+    devices:
+      - /dev/net/tun                         # ocserv is a userspace VPN server, so it DOES need TUN
+    sysctls:
+      - net.ipv4.ip_forward=1                # required on the downstream too
+    ports:
+      - "8443:443/tcp"                       # published normally on ocserv itself
+    environment:
+      - VPN_SUBNET=10.20.0.0/24              # address pool handed to OpenConnect clients
+      - VPN_GATEWAY=172.20.0.2               # route those clients out via the nordvpn-wg gateway
+      - IPV6_FORWARD=0
+      - IPV6_NAT=0
+    networks:
+      ocservnet:
+        ipv4_address: 172.20.0.3
+    restart: unless-stopped
+```
+
+Flow: an OpenConnect client gets an address from `10.20.0.0/24` → `ocserv` masquerades it to its own `172.20.0.3` (inside the `FORWARD_FROM` net) and policy-routes it to `172.20.0.2` → `nordvpn-wg` forwards it out the tunnel and masquerades it onto `wg0`. Replies return the same way. The client's public IP is then the NordVPN exit, and if the tunnel drops the kill switch blocks the forwarded traffic too.
+
+> **Both containers need `net.ipv4.ip_forward=1`** (set above via `sysctls`). The `nordvpn-wg` gateway also needs `net.ipv4.conf.all.src_valid_mark=1` like any WireGuard container.
+
+## Downstream containers without a built-in gateway option
+
+`azinchen/ocserv-server` handles routing via `VPN_GATEWAY`. For a generic downstream container that has no such option, route **only the client subnet** out through the gateway with a policy rule, keeping the container's default route on the docker bridge.
+
+Do **not** simply point the downstream's **default route** at the gateway — it breaks the downstream's own published ports: an inbound connection is `DNAT`ed in, but its reply would follow the default route into the tunnel and exit with the wrong source IP, so the client drops it.
+
+```sh
+# on the downstream container; 172.20.0.2 = the nordvpn-wg gateway
+ip route replace default via 172.20.0.2 table 100
+ip rule add from 10.20.0.0/24 lookup 100 priority 1000
+```
+
+The routing decision happens before the downstream container's own SNAT, so the `from 10.20.0.0/24` match works; client traffic goes to the gateway, while the listener's replies and the container's own traffic stay on the bridge.
+
+## Security Notes
+
+- **Keep `FORWARD_FROM` as narrow as possible** — every listed CIDR may route out through the tunnel.
+- Forwarding is gated on `wg0`, so the kill switch still applies: no tunnel, no forwarding.
+- This does **not** open any inbound ports on the gateway; publish the downstream service's ports on the downstream container.

--- a/wiki/_Footer.md
+++ b/wiki/_Footer.md
@@ -1,0 +1,7 @@
+---
+
+**[NordVPN WireGuard Docker Container](https://github.com/azinchen/nordvpn-wg)** · [README](https://github.com/azinchen/nordvpn-wg#readme) · [Releases](https://github.com/azinchen/nordvpn-wg/releases) · [Issues](https://github.com/azinchen/nordvpn-wg/issues) · [Docker Hub](https://hub.docker.com/r/azinchen/nordvpn-wg)
+
+Need OpenVPN instead? See the sibling project **[azinchen/nordvpn](https://github.com/azinchen/nordvpn)** ([wiki](https://github.com/azinchen/nordvpn/wiki)).
+
+Maintained by [Alexander Zinchenko](mailto:alexander@zinchenko.com) · Licensed under [AGPL-3.0](https://github.com/azinchen/nordvpn-wg/blob/main/LICENSE)

--- a/wiki/_Sidebar.md
+++ b/wiki/_Sidebar.md
@@ -1,0 +1,29 @@
+**[Home](Home)**
+
+**Configuration**
+- [Server Selection](Server-Selection)
+- [Server Groups](Server-Groups)
+- [IPv6 Configuration](IPv6-Configuration)
+- [Automatic Reconnection](Automatic-Reconnection)
+- [Local Network Access](Local-Network-Access)
+- [VPN Gateway Mode](VPN-Gateway-Mode)
+- [Custom DNS](Custom-DNS)
+- [Permissions](Permissions)
+
+**Security**
+- [Security Model](Security-Model)
+- [Firewall Backends](Firewall-Backends)
+
+**Examples**
+- [Docker Compose Examples](Docker-Compose-Examples)
+- [Docker Run Examples](Docker-Run-Examples)
+
+**Operations**
+- [Updating and Maintenance](Updating-and-Maintenance)
+- [Troubleshooting](Troubleshooting)
+- [Network Diagnostics Guide](Network-Diagnostics-Guide)
+
+**Reference**
+- [FAQ](FAQ)
+- [Supported Platforms](Supported-Platforms)
+- [Architecture and Internals](Architecture-and-Internals)


### PR DESCRIPTION
Same structure as azinchen/nordvpn#1217.

## Changes

- **Remove the `wiki` submodule** (`.gitmodules` + gitlink) and commit the wiki content (21 pages, taken from the submodule's current `master` @ `bb9b896`) as a regular `wiki/` folder in the main repo.
- **Add `.github/workflows/wiki-publish.yml`** — mirrors `wiki/` to the GitHub wiki repo (`rsync --delete`, so the wiki matches the folder exactly) on every **tag push**, plus `workflow_dispatch` for manual publishing. Pushes an empty marker commit when content is unchanged so every release leaves a trace in the wiki history.

## Why

- Wiki edits can ride feature branches and PRs (reviewable, atomic with code changes) instead of publishing live the moment they're pushed.
- Docs stay in sync with releases: the wiki updates when a release tag is pushed, not before.
- No more submodule pointer churn or forgetting to push the submodule.

Follow-up: the Firewall-Backends page update prepared for #208 will be added to that branch as a normal file change once this merges.