### PR TITLE
Centralize uplink and tunnel interface names

### DIFF
--- a/root/etc/s6-overlay/s6-rc.d/init-firewall/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-firewall/run
@@ -11,7 +11,7 @@ log "$SCRIPT_NAME" "Starting firewall initialization"
 log "$SCRIPT_NAME" "Configuring firewall to route all traffic through VPN"
 
 # BusyBox-friendly helpers
-docker_network="$(ip addr show dev eth0 2>/dev/null | awk '/inet / {print $2; exit}')"
+docker_network="$(ip addr show dev "$wan_if" 2>/dev/null | awk '/inet / {print $2; exit}')"
 gw="$(ip route 2>/dev/null | awk '/default/ {print $3; exit}')"
 
 # ===================== IPv4 =====================
@@ -23,12 +23,12 @@ if [ -n "$docker_network" ]; then
     run4_critical -A OUTPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
 
     # Allow outbound to VPN interfaces + NAT
-    run4_critical -A OUTPUT -o wg0 -j ACCEPT
-    run4_critical -t nat -A POSTROUTING -o wg0 -j MASQUERADE
+    run4_critical -A OUTPUT -o "$tun_if" -j ACCEPT
+    run4_critical -t nat -A POSTROUTING -o "$tun_if" -j MASQUERADE
 
     # Create named chain for VPN Server rules
     run4 -N VPN-SERVER
-    run4 -A OUTPUT -o eth0 -p udp --dport 51820 -j VPN-SERVER
+    run4 -A OUTPUT -o "$wan_if" -p udp --dport 51820 -j VPN-SERVER
 
     # NordVPN API bootstrap (TCP/443) by resolved IPs
     if [ -n "$nordvpnapi_ip" ]; then
@@ -43,7 +43,7 @@ if [ -n "$docker_network" ]; then
             # win. Without this route a dead tunnel makes the API unreachable,
             # and vpn-reconnect can never fetch the key/server list to recover.
             if [ -n "$gw" ]; then
-                ip route add "$ip" via "$gw" dev eth0 2>/dev/null || true
+                ip route add "$ip" via "$gw" dev "$wan_if" 2>/dev/null || true
             fi
         done
         IFS="$oldIFS"
@@ -57,12 +57,12 @@ if [ -n "$docker_network" ]; then
             [ -z "$net" ] && continue
             # Best-effort route add (if not already present)
             if [ -n "$gw" ]; then
-                ip route 2>/dev/null | grep -q " ${net} " || ip route add "$net" via "$gw" dev eth0 2>/dev/null || true
+                ip route 2>/dev/null | grep -q " ${net} " || ip route add "$net" via "$gw" dev "$wan_if" 2>/dev/null || true
             fi
             # Allow inbound from this network only
-            run4 -A INPUT -i eth0 -s "$net" -j ACCEPT
+            run4 -A INPUT -i "$wan_if" -s "$net" -j ACCEPT
             # Allow outbound to this network only
-            run4 -A OUTPUT -o eth0 -d "$net" -j ACCEPT
+            run4 -A OUTPUT -o "$wan_if" -d "$net" -j ACCEPT
         done
         IFS="$oldIFS"
     fi
@@ -77,14 +77,14 @@ if [ -n "$docker_network" ]; then
         oldIFS="$IFS"; IFS=',;'
         for net in $forward_from; do
             [ -z "$net" ] && continue
-            run4_critical -A FORWARD -s "$net" -o wg0 -j ACCEPT
-            run4_critical -A FORWARD -d "$net" -i wg0 \
+            run4_critical -A FORWARD -s "$net" -o "$tun_if" -j ACCEPT
+            run4_critical -A FORWARD -d "$net" -i "$tun_if" \
                 -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
         done
         IFS="$oldIFS"
     fi
 else
-    log "$SCRIPT_NAME" "No IPv4 address on eth0, skipping IPv4 rules"
+    log "$SCRIPT_NAME" "No IPv4 address on ${wan_if}, skipping IPv4 rules"
 fi
 
 log "$SCRIPT_NAME" "Firewall initialization completed"

--- a/root/etc/s6-overlay/s6-rc.d/svc-nordvpn/finish
+++ b/root/etc/s6-overlay/s6-rc.d/svc-nordvpn/finish
@@ -9,11 +9,11 @@ SCRIPT_NAME="SERVICE-NORDVPN"
 
 log "$SCRIPT_NAME" "Stopping NordVPN service"
 
-if wg show wg0 >/dev/null 2>&1; then
+if wg show "$tun_if" >/dev/null 2>&1; then
     log "$SCRIPT_NAME" "Disconnecting WireGuard"
-    wg-quick down wg0 || true
+    wg-quick down "$tun_if" || true
 else
-    log "$SCRIPT_NAME" "Interface wg0 not found, skipping wg-quick down"
+    log "$SCRIPT_NAME" "Interface ${tun_if} not found, skipping wg-quick down"
 fi
 rm -f "$wgfile"
 

--- a/root/usr/local/bin/backend-functions
+++ b/root/usr/local/bin/backend-functions
@@ -22,6 +22,11 @@ network="${NETWORK:-}"
 forward_from="${FORWARD_FROM:-}"
 dns="${DNS:-103.86.96.100;103.86.99.100}"
 
+# Interfaces. tun_if must match the basename of $wgfile (wg-quick derives
+# the interface name from the config file name).
+wan_if="eth0"
+tun_if="wg0"
+
 # Common file paths
 wgfile="/etc/wireguard/wg0.conf"
 countriesfile="/usr/local/share/nordvpn/data/countries.json"
@@ -57,9 +62,9 @@ run6_critical() {
     fi
 }
 
-# Check if VPN is connected by checking for wg0 interface
+# Check if VPN is connected by checking for the tunnel interface
 is_vpn_connected() {
-    if ip link show wg0 >/dev/null 2>&1; then
+    if ip link show "$tun_if" >/dev/null 2>&1; then
         return 0
     else
         return 1
@@ -67,8 +72,8 @@ is_vpn_connected() {
 }
 
 # Apply the WireGuard configuration currently in $wgfile: refresh the single
-# eth0 pinhole for the server endpoint, (re)bring the wg0 interface, and point
-# resolv.conf at the VPN DNS. Expects vpn-config to have written $wgfile.
+# uplink pinhole for the server endpoint, (re)bring the tunnel interface, and
+# point resolv.conf at the VPN DNS. Expects vpn-config to have written $wgfile.
 # Shared by the service start path and vpn-reconnect so the bring-up logic
 # lives in one place. $1 = log tag. Returns non-zero only if $wgfile has no
 # Endpoint (i.e. nothing to bring up).
@@ -84,17 +89,17 @@ apply_wireguard_config() {
     endpoint_value="$(echo "$endpoint_line" | sed 's/.*= *//; s/^[[:space:]]*//; s/[[:space:]]*$//')"
     r_ip="$(echo "$endpoint_value" | cut -d: -f1 | sed 's,^\[,,; s,\]$,,')"
 
-    # Refresh the eth0 pinhole for the (possibly new) server. Flushing first
+    # Refresh the uplink pinhole for the (possibly new) server. Flushing first
     # keeps the chain from accumulating stale server IPs across reconnects.
     run4 -F VPN-SERVER
-    if run4 -A VPN-SERVER -o eth0 -d "${r_ip}" -j ACCEPT; then
-        log "$_sn" "Pinhole added: VPN-SERVER -> ${r_ip} (eth0)"
+    if run4 -A VPN-SERVER -o "$wan_if" -d "${r_ip}" -j ACCEPT; then
+        log "$_sn" "Pinhole added: VPN-SERVER -> ${r_ip} (${wan_if})"
     fi
 
     # Swap the interface. This down/up is the only window without a tunnel.
     log "$_sn" "Launching WireGuard..."
-    ip link show wg0 >/dev/null 2>&1 && wg-quick down wg0 || true
-    wg-quick up wg0
+    ip link show "$tun_if" >/dev/null 2>&1 && wg-quick down "$tun_if" || true
+    wg-quick up "$tun_if"
 
     # Configure DNS through the tunnel. Docker's embedded resolver (127.0.0.11)
     # is unreachable behind the kill switch, so resolv.conf is written directly

--- a/root/usr/local/bin/network-diagnostic
+++ b/root/usr/local/bin/network-diagnostic
@@ -193,7 +193,7 @@ PUBLIC_TEST_IPv6="2606:4700:4700::1111"
 
 # Initialize variables with defaults
 COMMON_NAME=""
-DEV_IF="wg0"
+DEV_IF="$tun_if"
 DEV_TYPE="wireguard"
 IFCONF_LOCAL="?"
 IFCONF_REMOTE="?"

--- a/root/usr/local/bin/vpn-reconnect
+++ b/root/usr/local/bin/vpn-reconnect
@@ -39,5 +39,5 @@ if is_vpn_connected; then
     exit 0
 fi
 
-log_error "$SCRIPT_NAME" "wg0 not present after reconnect"
+log_error "$SCRIPT_NAME" "${tun_if} not present after reconnect"
 exit 1


### PR DESCRIPTION
## Summary

Replaces the `eth0`/`wg0` literals scattered across the scripts with `wan_if`/`tun_if` variables defined once in `backend-functions`, mirroring the sibling `azinchen/openconnect-client` image (part of syncing conventions across the three gateway images).

No functional change — the values are still `eth0`/`wg0`; `tun_if` must match the basename of `$wgfile` because wg-quick derives the interface name from the config file name.

## Changes

- `backend-functions`: new `wan_if`/`tun_if` definitions; `is_vpn_connected` and `apply_wireguard_config` use them
- `init-firewall/run`, `svc-nordvpn/finish`, `vpn-reconnect`, `network-diagnostic`: literals replaced with the variables

## Testing

- `sh -n` on all modified scripts
- `git grep` confirms no functional `eth0`/`wg0` literals remain outside comments and `$wgfile`