### PR TITLE
Port v7.2.0 fixes from upstream nordvpn

### DIFF
--- a/root/etc/s6-overlay/s6-rc.d/init-firewall/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-firewall/run
@@ -35,6 +35,7 @@ if [ -n "$docker_network" ]; then
         log "$SCRIPT_NAME" "Allowing NordVPN API access for IPs: ${nordvpnapi_ip}"
         oldIFS="$IFS"; IFS=',;'
         for ip in $nordvpnapi_ip; do
+            ip="$(trim "$ip")"
             [ -z "$ip" ] && continue
             run4 -A OUTPUT -d "$ip" -p tcp --dport 443 -j ACCEPT
             # Pin a host route via eth0 so API traffic stays off the tunnel.
@@ -54,10 +55,14 @@ if [ -n "$docker_network" ]; then
         log "$SCRIPT_NAME" "Allowing access to custom networks: ${network}"
         oldIFS="$IFS"; IFS=',;'
         for net in $network; do
+            net="$(trim "$net")"
             [ -z "$net" ] && continue
-            # Best-effort route add (if not already present)
+            # Best-effort route add (if not already present); warn instead of
+            # failing so one bad value doesn't block the rest, but stays visible
             if [ -n "$gw" ]; then
-                ip route 2>/dev/null | grep -q " ${net} " || ip route add "$net" via "$gw" dev "$wan_if" 2>/dev/null || true
+                ip route 2>/dev/null | grep -q " ${net} " \
+                    || ip route add "$net" via "$gw" dev "$wan_if" 2>/dev/null \
+                    || log_warning "$SCRIPT_NAME" "Warning: failed to add route for NETWORK value \"$net\""
             fi
             # Allow inbound from this network only
             run4 -A INPUT -i "$wan_if" -s "$net" -j ACCEPT
@@ -76,6 +81,7 @@ if [ -n "$docker_network" ]; then
         log "$SCRIPT_NAME" "Allowing tunnel forwarding from: ${forward_from}"
         oldIFS="$IFS"; IFS=',;'
         for net in $forward_from; do
+            net="$(trim "$net")"
             [ -z "$net" ] && continue
             run4_critical -A FORWARD -s "$net" -o "$tun_if" -j ACCEPT
             run4_critical -A FORWARD -d "$net" -i "$tun_if" \
@@ -111,14 +117,14 @@ if [ -n "$docker_network" ]; then
         dns_target=""
         case "$gateway_dns" in
             redirect)
-                dns_target="$(echo "$dns" | tr ',;' '\n' | grep -v ':' | head -1)"
+                dns_target="$(trim "$(echo "$dns" | tr ',;' '\n' | grep -v ':' | awk 'NF {print; exit}')")"
                 if [ -z "$dns_target" ]; then
                     log_error "$SCRIPT_NAME" "CRITICAL ERROR: GATEWAY_DNS=redirect requires an IPv4 resolver in DNS - sleeping infinite"
                     sleep infinity
                 fi
                 ;;
             forward)
-                dns_target="$(echo "$gateway_dns_server" | tr ',;' '\n' | grep -v ':' | head -1)"
+                dns_target="$(trim "$(echo "$gateway_dns_server" | tr ',;' '\n' | grep -v ':' | awk 'NF {print; exit}')")"
                 if [ -z "$dns_target" ]; then
                     log_error "$SCRIPT_NAME" "CRITICAL ERROR: GATEWAY_DNS=forward requires an IPv4 GATEWAY_DNS_SERVER - sleeping infinite"
                     sleep infinity
@@ -128,6 +134,7 @@ if [ -n "$docker_network" ]; then
         log "$SCRIPT_NAME" "Intercepting client DNS: mode=${gateway_dns}${dns_target:+ target=$dns_target}"
         oldIFS="$IFS"; IFS=',;'
         for net in $forward_from; do
+            net="$(trim "$net")"
             [ -z "$net" ] && continue
             for proto in udp tcp; do
                 case "$gateway_dns" in

--- a/root/etc/s6-overlay/s6-rc.d/init-setupcron/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-setupcron/run
@@ -19,22 +19,29 @@ fi
 if [ -n "${check_connection_cron:-}" ]; then
     log "$SCRIPT_NAME" "Health check cron: $check_connection_cron ($(parse_cron "$check_connection_cron"))"
     
-    # Validate CHECK_CONNECTION_* variables that are used by vpn-healthcheck
-    
-    if [ -z "$check_connection_attempts" ] || [ "$check_connection_attempts" -le 0 ]; then
-        log_error "$SCRIPT_NAME" "ERROR: CHECK_CONNECTION_ATTEMPTS must be a positive integer, got: '$check_connection_attempts'"
-        exit 1
-    fi
-    
+    # Validate CHECK_CONNECTION_* variables that are used by vpn-healthcheck.
+    # Pattern check instead of [ -le 0 ]: a numeric test on a non-numeric value
+    # errors (status 2), which inside an `if` condition just evaluates as
+    # false, silently skipping the validation.
+
+    case "$check_connection_attempts" in
+        ''|0|*[!0-9]*)
+            log_error "$SCRIPT_NAME" "ERROR: CHECK_CONNECTION_ATTEMPTS must be a positive integer, got: '$check_connection_attempts'"
+            exit 1
+            ;;
+    esac
+
     if [ -z "$check_connection_url" ]; then
         log_error "$SCRIPT_NAME" "ERROR: CHECK_CONNECTION_URL must be set"
         exit 1
     fi
-    
-    if [ -z "$check_connection_attempt_interval" ] || [ "$check_connection_attempt_interval" -le 0 ]; then
-        log_error "$SCRIPT_NAME" "ERROR: CHECK_CONNECTION_ATTEMPT_INTERVAL must be a positive integer, got: '$check_connection_attempt_interval'"
-        exit 1
-    fi
+
+    case "$check_connection_attempt_interval" in
+        ''|0|*[!0-9]*)
+            log_error "$SCRIPT_NAME" "ERROR: CHECK_CONNECTION_ATTEMPT_INTERVAL must be a positive integer, got: '$check_connection_attempt_interval'"
+            exit 1
+            ;;
+    esac
     
     # Validation passed
 else

--- a/root/etc/s6-overlay/s6-rc.d/svc-cron/dependencies
+++ b/root/etc/s6-overlay/s6-rc.d/svc-cron/dependencies
@@ -1,1 +1,2 @@
 init-setupcron
+svc-nordvpn

--- a/root/usr/local/bin/backend-functions
+++ b/root/usr/local/bin/backend-functions
@@ -35,6 +35,16 @@ countriesfile="/usr/local/share/nordvpn/data/countries.json"
 groupsfile="/usr/local/share/nordvpn/data/groups.json"
 technologiesfile="/usr/local/share/nordvpn/data/technologies.json"
 
+# Strip leading/trailing whitespace from a list token. Values like
+# "10.0.0.0/16; 10.1.0.0/16" split on IFS=',;' keep the space, which then
+# breaks ip/iptables/curl silently. Pure-shell so it works under BusyBox.
+trim() {
+    _t="$1"
+    _t="${_t#"${_t%%[![:space:]]*}"}"
+    _t="${_t%"${_t##*[![:space:]]}"}"
+    printf '%s' "$_t"
+}
+
 run4() {
     if ! ${IPT} "$@" 2>/dev/null; then
         log "BACKEND" "(IPv4) skipped: $*"

--- a/root/usr/local/bin/backend-functions
+++ b/root/usr/local/bin/backend-functions
@@ -45,9 +45,20 @@ trim() {
     printf '%s' "$_t"
 }
 
+# Best-effort by design: always returns 0 so plain call sites under `set -e`
+# never abort the caller. Use run4_check when the caller needs the real status.
 run4() {
     if ! ${IPT} "$@" 2>/dev/null; then
         log "BACKEND" "(IPv4) skipped: $*"
+    fi
+}
+
+# Like run4 but propagates the iptables exit status, for callers that branch
+# on whether the rule was actually added.
+run4_check() {
+    if ! ${IPT} "$@" 2>/dev/null; then
+        log "BACKEND" "(IPv4) skipped: $*"
+        return 1
     fi
 }
 
@@ -104,8 +115,10 @@ apply_wireguard_config() {
     # Refresh the uplink pinhole for the (possibly new) server. Flushing first
     # keeps the chain from accumulating stale server IPs across reconnects.
     run4 -F VPN-SERVER
-    if run4 -A VPN-SERVER -o "$wan_if" -d "${r_ip}" -j ACCEPT; then
+    if run4_check -A VPN-SERVER -o "$wan_if" -d "${r_ip}" -j ACCEPT; then
         log "$_sn" "Pinhole added: VPN-SERVER -> ${r_ip} (${wan_if})"
+    else
+        log_warning "$_sn" "Warning: failed to add firewall pinhole for ${r_ip} - connection to this server may be blocked"
     fi
 
     # Swap the interface. This down/up is the only window without a tunnel.

--- a/root/usr/local/bin/vpn-config
+++ b/root/usr/local/bin/vpn-config
@@ -226,6 +226,7 @@ nord_api_curl()
 
     oldIFS="$IFS"; IFS=',;'; _rc=1
     for _ip in $nordvpnapi_ip; do
+        _ip="$(trim "$_ip")"
         [ -n "$_ip" ] || continue
 
         curl -sG --connect-timeout 10 --max-time 30 \
@@ -284,6 +285,7 @@ if [ -n "$country" ]; then
     # Convert semicolon/comma separated list to space separated
     oldIFS="$IFS"; IFS=',;'
     for value in $country; do
+        value="$(trim "$value")"
         if [ -n "$value" ]; then
             locations_count=$((locations_count + 1))
         fi
@@ -320,6 +322,7 @@ if [ -n "$city" ]; then
     # Convert semicolon/comma separated list to space separated
     oldIFS="$IFS"; IFS=',;'
     for value in $city; do
+        value="$(trim "$value")"
         if [ -n "$value" ]; then
             locations_count=$((locations_count + 1))
         fi

--- a/root/usr/local/bin/vpn-config
+++ b/root/usr/local/bin/vpn-config
@@ -247,8 +247,13 @@ if [ -z "${TOKEN:-}" ]; then
 fi
 
 log "$SCRIPT_NAME" "Fetching WireGuard private key from NordVPN API using TOKEN"
-private_key="$(nord_api_curl "v1/users/services/credentials" -u "token:${TOKEN}" 2>/dev/null \
+# Pass the token via a 0600 curl config file, not -u on the command line,
+# so it never appears in /proc/*/cmdline or ps output
+curlcfg="$(mktemp /run/xt/curl-auth.XXXXXX)"
+printf 'user = "token:%s"\n' "$TOKEN" > "$curlcfg"
+private_key="$(nord_api_curl "v1/users/services/credentials" -K "$curlcfg" 2>/dev/null \
     | jq -r '.nordlynx_private_key // empty' 2>/dev/null || echo "")"
+rm -f "$curlcfg"
 
 if [ -z "$private_key" ]; then
     log_error "$SCRIPT_NAME" "CRITICAL: could not obtain WireGuard private key from NordVPN API (check TOKEN)"

--- a/root/usr/local/bin/vpn-config
+++ b/root/usr/local/bin/vpn-config
@@ -290,9 +290,15 @@ if [ -n "$country" ]; then
             locations_count=$((locations_count + 1))
         fi
         if is_specific_server "$value"; then
-            servers="$servers$(handle_specific_server "$value")"
+            # `|| true` so an unknown/retired hostname doesn't kill the script
+            # under `set -e`; handle_specific_server already logs the failure
+            # and the loop continues with the remaining values.
+            servers="$servers$(handle_specific_server "$value" || true)"
         elif [ -n "$value" ]; then
-            countryid=$(getcountryid "$value")
+            # `|| true` so an unknown country (e.g. user passing a US state code)
+            # doesn't silently kill the script under `set -e`; the -z branch
+            # below logs the warning and the loop continues.
+            countryid=$(getcountryid "$value" || true)
             if [ -n "$countryid" ]; then
                 # Build curl parameters
                 curl_params="$tech_filter --data-urlencode filters[country_id]=$countryid"
@@ -327,8 +333,12 @@ if [ -n "$city" ]; then
             locations_count=$((locations_count + 1))
         fi
         if is_specific_server "$value"; then
-            servers="$servers$(handle_specific_server "$value")"
+            # `|| true` so an unknown/retired hostname doesn't kill the script
+            # under `set -e`; handle_specific_server already logs the failure
+            # and the loop continues with the remaining values.
+            servers="$servers$(handle_specific_server "$value" || true)"
         elif [ -n "$value" ]; then
+            # See COUNTRY loop above for the rationale behind `|| true`.
             cityid=$(getcityid "$value" || true)
             if [ -n "$cityid" ]; then
                 # Build curl parameters

--- a/root/usr/local/bin/vpn-healthcheck
+++ b/root/usr/local/bin/vpn-healthcheck
@@ -23,6 +23,8 @@ while [ $counter -le "$check_connection_attempts" ]; do
     # Convert semicolon separated list to space separated
     oldIFS="$IFS"; IFS=',;'
     for url in $check_connection_url; do
+        url="$(trim "$url")"
+        [ -n "$url" ] || continue
         if httpreq "$url"; then
             log "$SCRIPT_NAME" "VPN connection is active"
             exit 0

--- a/root/usr/local/bin/vpn-healthcheck-probe
+++ b/root/usr/local/bin/vpn-healthcheck-probe
@@ -25,6 +25,7 @@ is_vpn_connected || exit 1
 #    request (no retry loop; Docker --retries absorbs transient blips).
 oldIFS="$IFS"; IFS=',;'
 for url in $check_connection_url; do
+    url="$(trim "$url")"
     [ -n "$url" ] || continue
     code="$(curl -s --max-time 5 -o /dev/null -w '%{http_code}' -I "$url" 2>/dev/null || printf '000')"
     case "$code" in

--- a/root/usr/local/bin/vpn-reconnect
+++ b/root/usr/local/bin/vpn-reconnect
@@ -7,6 +7,28 @@ set -eu
 
 SCRIPT_NAME="VPN-RECONNECT"
 
+# Serialize reconnections: RECREATE_VPN_CRON, CHECK_CONNECTION_CRON (via
+# vpn-healthcheck) and manual invocations are independent and can overlap;
+# two concurrent runs would race on the shared WireGuard config file and
+# interleave wg-quick down/up calls. mkdir is atomic, so it doubles as a
+# lock; a lock whose owner is gone (crashed mid-run) is taken over.
+lockdir="/run/xt/vpn-reconnect.lock"
+if ! mkdir "$lockdir" 2>/dev/null; then
+    holder="$(cat "$lockdir/pid" 2>/dev/null || true)"
+    if [ -n "$holder" ] && [ -d "/proc/$holder" ]; then
+        log "$SCRIPT_NAME" "Another reconnection (pid $holder) is already in progress - skipping"
+        exit 0
+    fi
+    log_warning "$SCRIPT_NAME" "Removing stale reconnection lock (owner gone)"
+    rm -rf "$lockdir"
+    if ! mkdir "$lockdir" 2>/dev/null; then
+        log "$SCRIPT_NAME" "Another reconnection grabbed the lock first - skipping"
+        exit 0
+    fi
+fi
+echo "$$" > "$lockdir/pid"
+trap 'rm -rf "$lockdir"' EXIT INT TERM
+
 log "$SCRIPT_NAME" "Starting VPN reconnection"
 
 # Select a new server and write the new config while the CURRENT tunnel stays


### PR DESCRIPTION
Ports the seven applicable bug fixes from azinchen/nordvpn v7.1.0..v7.2.0, adapted for the WireGuard scripts where needed:

- **Trim whitespace around delimited list values** (upstream ee6722b) — new `trim()` helper in backend-functions, applied in every `IFS=',;'` split loop (`NORDVPNAPI_IP`, `NETWORK`, `FORWARD_FROM`, `COUNTRY`, `CITY`, `CHECK_CONNECTION_URL`, `DNS`, `GATEWAY_DNS_SERVER`).
- **Report firewall pinhole failures** (60837b1) — `run4` always returns 0, so `apply_wireguard_config` logged "Pinhole added" even on failure; new `run4_check` propagates the iptables status and a warning is logged instead.
- **Reject non-numeric `CHECK_CONNECTION_*` values** (e4e873b) — `[ x -le 0 ]` errors on non-numeric input and silently passes inside `if`; replaced with case pattern checks.
- **Start crond only after svc-nordvpn** (7760c6a) — prevents cron firing vpn-reconnect/vpn-healthcheck before the first connection attempt.
- **Serialize concurrent vpn-reconnect runs** (4f2c845) — atomic mkdir lock with stale-owner takeover; cron reconnects, healthcheck-triggered reconnects and manual runs could previously overlap and race on the config/`wg-quick` swap.
- **Continue selection when a specific-server lookup fails** (5e82482) — `|| true` on `handle_specific_server` (and `getcountryid`, aligning with the existing `getcityid` guard) so one retired hostname doesn't kill the whole selection under `set -e`.
- **Keep TOKEN off the process command line** (ca31165) — the private-key fetch now passes the token via a 0600 curl config file (`-K`) instead of `-u`, so it no longer shows in `/proc/*/cmdline`/`ps`.