### PR TITLE
Publish selected server as /run/xt/status.json

### DIFF
--- a/root/usr/local/bin/vpn-config
+++ b/root/usr/local/bin/vpn-config
@@ -465,5 +465,27 @@ fi
 mv "${wgfile}.tmp" "$wgfile"
 sync
 
+# Publish the selection as machine-readable JSON for monitoring/dashboards.
+# Written only after the config is in place, so the file always describes the
+# server the (next) connection actually uses. Best-effort: a write failure
+# must not break configuration.
+load="$(echo "$servers" | jq -r '.load // 0' | head -n 1 || true)"
+if jq -n \
+    --arg name "$name" \
+    --arg hostname "$hostname" \
+    --arg ip "$serverip" \
+    --arg technology "wireguard" \
+    --arg country "$country_name" \
+    --arg city "$city_name" \
+    --argjson load "${load:-0}" \
+    --arg selected_at "$(date -u +'%Y-%m-%dT%H:%M:%SZ')" \
+    '{name: $name, hostname: $hostname, ip: $ip, technology: $technology,
+      country: $country, city: $city, load: $load,
+      selected_at: $selected_at}' > /run/xt/status.json 2>/dev/null; then
+    chmod 0644 /run/xt/status.json 2>/dev/null || true
+else
+    log_warning "$SCRIPT_NAME" "Could not write /run/xt/status.json"
+fi
+
 log "$SCRIPT_NAME" "VPN configuration completed"
 exit 0

--- a/wiki/Architecture-and-Internals.md
+++ b/wiki/Architecture-and-Internals.md
@@ -127,6 +127,7 @@ Located in `/usr/local/share/nordvpn/data/`:
 |------|---------|
 | `/run/xt/backend.env` | Selected iptables backend (IPT, IP6T) |
 | `/etc/wireguard/wg0.conf` | Current server's WireGuard config (private key, peer, endpoint) |
+| `/run/xt/status.json` | Last selected server as JSON (name, hostname, ip, technology, country, city, load, selected_at) — world-readable, for monitoring, e.g. `docker exec vpn cat /run/xt/status.json` |
 
 ## Connection Status
 


### PR DESCRIPTION
Ports azinchen/nordvpn@206b2eb, adapted for WireGuard: after `vpn-config` swaps the new config into place, it writes the selected server as machine-readable JSON to `/run/xt/status.json` (world-readable) for monitoring/dashboards:

```json
{"name": "...", "hostname": "...", "ip": "...", "technology": "wireguard", "country": "...", "city": "...", "load": 12, "selected_at": "2026-08-11T..."}
```

The `protocol` field from upstream is dropped and `technology` is fixed to `wireguard`, since this image is WireGuard-only. The write is best-effort — a failure logs a warning and never breaks configuration. Documented in the Architecture wiki's state-files table.