### PR TITLE
Fix specific-server selection, group fallback, and error propagation

### DIFF
--- a/root/usr/local/bin/backend-functions
+++ b/root/usr/local/bin/backend-functions
@@ -1,8 +1,13 @@
 #!/bin/sh
 # shellcheck shell=sh
 
-# Reuse backend selected by entrypoint
+# Reuse backend selected by entrypoint. Default the backends afterwards so
+# scripts running under `set -u` fail with a clear log line instead of an
+# "IPT: parameter not set" abort when backend.env is missing (e.g. a manual
+# docker exec after /run was cleared).
 [ -r /run/xt/backend.env ] && . /run/xt/backend.env
+IPT="${IPT:-iptables}"
+IP6T="${IP6T:-}"
 
 # Create lowercase copies of environment variables
 to_bool() { case "${1:-}" in true|1) echo "true" ;; *) echo "false" ;; esac; }
@@ -122,9 +127,15 @@ apply_wireguard_config() {
     fi
 
     # Swap the interface. This down/up is the only window without a tunnel.
+    # The explicit failure check matters: callers invoke this function in a
+    # conditional context (if/||), which disables `set -e` inside it, so a
+    # failed wg-quick would otherwise fall through and return success.
     log "$_sn" "Launching WireGuard..."
     ip link show "$tun_if" >/dev/null 2>&1 && wg-quick down "$tun_if" || true
-    wg-quick up "$tun_if"
+    if ! wg-quick up "$tun_if"; then
+        log_error "$_sn" "CRITICAL: wg-quick up $tun_if failed"
+        return 1
+    fi
 
     # Configure DNS through the tunnel. Docker's embedded resolver (127.0.0.11)
     # is unreachable behind the kill switch, so resolv.conf is written directly

--- a/root/usr/local/bin/vpn-config
+++ b/root/usr/local/bin/vpn-config
@@ -433,15 +433,26 @@ fi
 # If no servers found, fallback to default recommended servers
 if [ "$poollength" -eq 0 ]; then
     log "$SCRIPT_NAME" "No servers found for specified criteria, requesting default recommended servers"
-    
-    # Build curl parameters for fallback
+
+    # Build curl parameters for fallback. GROUP is kept on the first attempt:
+    # when only GROUP is set (no COUNTRY/CITY), this path IS the primary
+    # query, not a fallback.
     curl_params="$tech_filter"
     if [ -n "$group_filter" ]; then
         curl_params="$curl_params $group_filter"
     fi
-    
+
     servers=$(eval "nord_api_curl \"v1/servers/recommendations\" $curl_params 2>/dev/null | jq -c '.[]' 2>/dev/null || echo \"\"")
-    
+
+    # Second stage: a group with no NordLynx servers (e.g. an OpenVPN-only
+    # group) yields an empty response forever - retry once without the group
+    # filter so the container still comes up on the recommended pool instead
+    # of failing hard.
+    if [ -z "$servers" ] && [ -n "$group_filter" ]; then
+        log_warning "$SCRIPT_NAME" "No servers in group \"$group\" support WireGuard - retrying without the group filter"
+        servers=$(eval "nord_api_curl \"v1/servers/recommendations\" $tech_filter 2>/dev/null | jq -c '.[]' 2>/dev/null || echo \"\"")
+    fi
+
     if [ -n "$servers" ]; then
         log "$SCRIPT_NAME" "Default recommended servers: $(echo "$servers" | jq -s 'length') servers received"
         echo "$servers" | jq -r '[.name, .hostname, .load, .locations[0].country.name, .locations[0].country.city.name] | "\(.[1]): \(.[2])% load - \(.[3]), \(.[4]) (\(.[0]))"'

--- a/root/usr/local/bin/vpn-config
+++ b/root/usr/local/bin/vpn-config
@@ -41,14 +41,33 @@ is_numeric()
 is_specific_server()
 {
     case "$1" in
-        [a-zA-Z][a-zA-Z][0-9]*)
-            # Check if it's exactly 2 letters followed by numbers
-            prefix=$(echo "$1" | cut -c1-2)
-            suffix=$(echo "$1" | cut -c3-)
-            case "$prefix" in
-                [a-zA-Z][a-zA-Z]) ;;
-                *) return 1 ;;
+        # SOCKS pattern: socks-xx{num} (e.g., socks-nl1, socks-se8)
+        socks-[a-zA-Z][a-zA-Z][0-9]*)
+            suffix=$(echo "$1" | sed 's/^socks-[a-zA-Z][a-zA-Z]//')
+            case "$suffix" in
+                ''|*[!0-9]*) return 1 ;;
+                *) return 0 ;;
             esac
+            ;;
+        # Onion pattern: xx-onion{num} (e.g., nl-onion6, ch-onion2)
+        [a-zA-Z][a-zA-Z]-onion[0-9]*)
+            suffix=$(echo "$1" | sed 's/^[a-zA-Z][a-zA-Z]-onion//')
+            case "$suffix" in
+                ''|*[!0-9]*) return 1 ;;
+                *) return 0 ;;
+            esac
+            ;;
+        # Cross-country pattern: xx-yy{num} (e.g., ca-us100, uk-fr17)
+        [a-zA-Z][a-zA-Z]-[a-zA-Z][a-zA-Z][0-9]*)
+            suffix=$(echo "$1" | sed 's/^[a-zA-Z][a-zA-Z]-[a-zA-Z][a-zA-Z]//')
+            case "$suffix" in
+                ''|*[!0-9]*) return 1 ;;
+                *) return 0 ;;
+            esac
+            ;;
+        # Standard pattern: xx{num} (e.g., us5063, uk1784)
+        [a-zA-Z][a-zA-Z][0-9]*)
+            suffix=$(echo "$1" | cut -c3-)
             case "$suffix" in
                 ''|*[!0-9]*) return 1 ;;
                 *) return 0 ;;
@@ -206,17 +225,52 @@ getgrouptitle()
 handle_specific_server()
 {
     value=$1
-    
-    # Convert to lowercase using tr instead of ${value,,}
+
     hostname="$(echo "$value" | tr '[:upper:]' '[:lower:]').nordvpn.com"
-    ip="$(host -t A "$hostname" | awk '{print $4}')"
-    # Extract country code (first 2 chars) and number part
-    country_code=$(echo "$value" | cut -c1-2)
-    country_num=$(echo "$value" | cut -c3-)
-    name="$(getcountryname "$country_code") #$country_num"
-    constructed_json=$(printf '{"name":"%s","hostname":"%s","load":0,"station":"%s"}' "$name" "$hostname" "$ip")
-    
-    printf '%s' "$constructed_json"
+
+    # The server is looked up via the NordVPN API (pinned IPs), never DNS:
+    # plain DNS is blocked by the default-deny firewall before the tunnel is
+    # up, and only the API response carries the WireGuard public key the
+    # [Peer] section needs.
+    # Note: all log calls use >&2 to avoid polluting stdout (captured by caller via $(...))
+
+    # Extract country code prefix from hostname pattern
+    case "$value" in
+        socks-*) cc=$(echo "$value" | cut -c7-8) ;;
+        *) cc=$(echo "$value" | cut -c1-2) ;;
+    esac
+    cc=$(echo "$cc" | tr '[:lower:]' '[:upper:]')
+
+    # Try to find country ID for optimized query (smaller response)
+    country_id=$(getcountryid "$cc" 2>/dev/null || echo "")
+
+    server_json=""
+    if [ -n "$country_id" ]; then
+        log "$SCRIPT_NAME" "Querying servers filtered by country code $cc (id=$country_id)" >&2
+        server_json=$(nord_api_curl "v1/servers" \
+            --data-urlencode "filters[country_id]=$country_id" \
+            --data-urlencode "limit=0" 2>/dev/null \
+            | jq -c --arg H "$hostname" '.[] | select(.hostname == $H)' 2>/dev/null \
+            | head -n 1 || echo "")
+    fi
+
+    # Fallback: query all servers if country code not found or country-filtered query didn't match
+    if [ -z "$server_json" ] || [ "$server_json" = "null" ]; then
+        log "$SCRIPT_NAME" "Querying all servers (country code $cc not matched or server not in country)" >&2
+        server_json=$(nord_api_curl "v1/servers" \
+            --data-urlencode "limit=0" 2>/dev/null \
+            | jq -c --arg H "$hostname" '.[] | select(.hostname == $H)' 2>/dev/null \
+            | head -n 1 || echo "")
+    fi
+
+    if [ -n "$server_json" ] && [ "$server_json" != "null" ]; then
+        log "$SCRIPT_NAME" "Found server $hostname via API (station: $(echo "$server_json" | jq -r '.station'))" >&2
+        printf '%s' "$server_json"
+        return 0
+    fi
+
+    log_error "$SCRIPT_NAME" "ERROR: Could not find server $hostname in NordVPN server list"
+    return 1
 }
 
 nord_api_curl()
@@ -428,14 +482,21 @@ if [ "$poollength" -eq 0 ]; then
     fail
 fi
 
-serverip=$(echo "$servers" | jq -r '.station' | head -n 1)
-name=$(echo "$servers" | jq -r '.name' | head -n 1)
-hostname=$(echo "$servers" | jq -r '.hostname' | head -n 1)
-serverkey=$(echo "$servers" | jq -r '.technologies[] | select(.id == 35) | .metadata[] | select(.name == "public_key") | .value' | head -n 1)
+# Take the first server of the pool ONCE and extract every field from that
+# same JSON object. Extracting each field from the whole stream with
+# `head -n 1` looks equivalent, but is not for the key: a first server
+# without a WireGuard entry would emit no key line, so `head -n 1` would
+# silently return the key of the NEXT server - an endpoint/key mismatch
+# that can never complete a handshake.
+selected=$(echo "$servers" | head -n 1)
+serverip=$(echo "$selected" | jq -r '.station')
+name=$(echo "$selected" | jq -r '.name')
+hostname=$(echo "$selected" | jq -r '.hostname')
+serverkey=$(echo "$selected" | jq -r '.technologies[] | select(.id == 35) | .metadata[] | select(.name == "public_key") | .value' | head -n 1)
 
 # Extract location information
-country_name=$(echo "$servers" | jq -r '.locations[0].country.name' | head -n 1)
-city_name=$(echo "$servers" | jq -r '.locations[0].country.city.name' | head -n 1)
+country_name=$(echo "$selected" | jq -r '.locations[0].country.name')
+city_name=$(echo "$selected" | jq -r '.locations[0].country.city.name')
 log "$SCRIPT_NAME" "Selected server \"$name\" hostname=\"$hostname\" ip=\"$serverip\" location=\"$country_name, $city_name\""
 
 if [ -z "$serverkey" ] || [ "$serverkey" = "null" ]; then
@@ -487,7 +548,7 @@ sync
 # Written only after the config is in place, so the file always describes the
 # server the (next) connection actually uses. Best-effort: a write failure
 # must not break configuration.
-load="$(echo "$servers" | jq -r '.load // 0' | head -n 1 || true)"
+load="$(echo "$selected" | jq -r '.load // 0' || true)"
 if jq -n \
     --arg name "$name" \
     --arg hostname "$hostname" \


### PR DESCRIPTION
Three code fixes from this week's audit:

- **Specific-server selection was broken.** `handle_specific_server` resolved the hostname with a plain DNS query — blocked by the default-deny firewall before the tunnel is up — and built a JSON stub with no `technologies` array, so a specific server (`COUNTRY=us5063` etc.) either failed to produce a WireGuard key or silently paired its endpoint with the public key of a **different** server (a handshake that can never complete). It now queries the NordVPN API via the pinned bootstrap IPs and returns the real server JSON, matching upstream's implementation; `is_specific_server` also recognizes `socks-nl1`, `nl-onion6`, and `ca-us100` hostname forms. Field extraction now reads all fields (ip, name, key, location, load) from the same first pool entry, eliminating the cross-server key mismatch by construction.
- **Group fallback couldn't fall back.** The "default recommended servers" request kept the group filter, so a group with no NordLynx servers returned empty forever and the container failed hard, contrary to the documented behavior. The filter is kept on the first attempt (with only `GROUP` set, that path is the primary query) and dropped on a second attempt with a warning.
- **`wg-quick up` failures were swallowed.** All callers invoke `apply_wireguard_config` in a conditional context, which disables `set -e` inside it; a failed bring-up fell through and returned success. Now checked explicitly. Also, `IPT`/`IP6T` get sane defaults after sourcing `backend.env`, so manual invocations without it fail with a clear message instead of a `set -u` abort.