### PR TITLE
CI: build on main, verify apk bumps across all architectures

### DIFF
--- a/.github/workflows/ci-build-deploy.yml
+++ b/.github/workflows/ci-build-deploy.yml
@@ -3,12 +3,12 @@ name: CI - Build and Deploy
 on:
   push:
     # Production builds: tags only -> push to both registries with latest tag
-    # Development builds: master and other branches -> push only to GHCR
+    # Development builds: main and other branches -> push only to GHCR
     branches: [ '**' ]
     tags: [ '**' ]
   pull_request:
-    # Only PRs targeting master branch
-    branches: [ master ]
+    # Only PRs targeting main branch
+    branches: [ main ]
 
 permissions:
   contents: read
@@ -23,7 +23,7 @@ concurrency:
   cancel-in-progress: ${{ github.ref_type != 'tag' }}
 
 env:
-  # Multi-platform builds for production (master/tags)
+  # Multi-platform builds for production (main/tags)
   PLATFORMS: "linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/ppc64le,linux/s390x,linux/riscv64"
   # Fast builds for development branches (amd64 only)
   DEV_PLATFORMS: "linux/amd64"  # Only build for amd64 on development branches for speed
@@ -72,9 +72,9 @@ jobs:
             IMAGE_TAG=${GITHUB_REF_NAME#v}
             PLATFORMS="${{ env.PLATFORMS }}"  # Build all platforms for tags
             PUSH_TO_PROD=true
-          elif [[ "$GITHUB_REF_NAME" == "master" ]]; then
+          elif [[ "$GITHUB_REF_NAME" == "main" ]]; then
             IMAGE_TAG="dev"  # Master branch tagged as 'dev'
-            PLATFORMS="${{ env.PLATFORMS }}"  # Build all platforms for master
+            PLATFORMS="${{ env.PLATFORMS }}"  # Build all platforms for main
             PUSH_TO_PROD=false
           else
             # Sanitize branch name for Docker tag (replace / and other invalid chars with -)
@@ -181,10 +181,10 @@ jobs:
   security-scan-built-image:
     name: 🔒 Security Scan - Built Image
     needs: build-and-deploy
-    # Only scan production-ish images (master + tags); feature-branch dev
+    # Only scan production-ish images (main + tags); feature-branch dev
     # images are throwaway and the daily cron already covers 'latest'.
     if: ${{ always() && needs.build-and-deploy.result == 'success'
-            && (github.ref_name == 'master' || github.ref_type == 'tag') }}
+            && (github.ref_name == 'main' || github.ref_type == 'tag') }}
     uses: ./.github/workflows/security-docker.yml
     with:
       image_tag: ${{ needs.build-and-deploy.outputs.image_tag }}

--- a/.github/workflows/security-comprehensive.yml
+++ b/.github/workflows/security-comprehensive.yml
@@ -6,9 +6,9 @@ permissions:
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
   schedule:
     - cron: '0 4 * * 1'  # Weekly, Mondays at 4 AM UTC
   workflow_dispatch:

--- a/.github/workflows/security-docker.yml
+++ b/.github/workflows/security-docker.yml
@@ -6,7 +6,7 @@ permissions:
 
 on:
   schedule:
-    - cron: '0 6 * * *'  # Run at 6 AM UTC daily to check latest production image on Docker Hub
+    - cron: '0 6 * * *'  # Run at 6 AM UTC daily to check the latest production image on GHCR (same digest as Docker Hub)
   workflow_dispatch:
     inputs:
       image_tag:
@@ -46,7 +46,7 @@ jobs:
           REGISTRY="ghcr"
           IMAGE_REF="ghcr.io/${{ github.repository }}:${IMAGE_TAG}"
           if [[ "${{ github.event_name }}" == "schedule" ]]; then
-            # Cron job: Always scan latest production image on 
+            # Cron job: Always scan the latest production image on GHCR
             IMAGE_TAG="latest"
             echo "🕒 Scheduled scan: Checking latest production image on GHCR"
           elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then

--- a/scripts/update-apk-versions.sh
+++ b/scripts/update-apk-versions.sh
@@ -46,6 +46,28 @@ extract_new_version()
     echo "$version"
 }
 
+# Architectures the image is built for (PLATFORMS in ci-build-deploy.yml),
+# mapped to Alpine repository architecture names.
+BUILD_ARCHES="x86 x86_64 armhf armv7 aarch64 ppc64le s390x riscv64"
+
+# Print the build architectures where pkg=version is NOT available in repo.
+# Empty output means the version exists everywhere; used to hold back updates
+# that Alpine has not yet built for all architectures we ship.
+missing_arches_for_version()
+{
+    local pkg="$1" repo="$2" version="$3"
+    local missing=""
+    for arch in $BUILD_ARCHES; do
+        [ "$arch" = "x86_64" ] && continue    # source of $version, already known
+        local v
+        v=$(extract_new_version "https://pkgs.alpinelinux.org/package/v${ALPINE_BRANCH}/${repo}/${arch}/${pkg}")
+        if [ "$v" != "$version" ]; then
+            missing="$missing $arch"
+        fi
+    done
+    echo "$missing"
+}
+
 # --- 4. Initialize variables to track updates ---
 UPDATED_PACKAGES=""
 TOTAL_PACKAGES=0
@@ -84,6 +106,13 @@ update_package_with_tracking() {
     fi
 
     if [ "$current_version" != "$new_version" ]; then
+        # Hold back the bump until Alpine has built it for every architecture
+        # we ship - x86_64 availability alone can break the multi-arch build
+        missing=$(missing_arches_for_version "$pkg" "$repo" "$new_version")
+        if [ -n "$missing" ]; then
+            echo "  ⚠ $new_version not yet available on:$missing - keeping $current_version"
+            return
+        fi
         echo "  Updating '$pkg' from $current_version to $new_version (found in $repo repo)"
         sed -i "s/${pkg}=${current_version}/${pkg}=${new_version}/g" "$DOCKERFILE"
         UPDATED_COUNT=$((UPDATED_COUNT + 1))


### PR DESCRIPTION
Two CI fixes from the audit:

- **Workflows still triggered on `master`.** The default branch is `main`, so `ci-build-deploy`'s `pull_request` job never fired, pushes to main were built as a development branch (amd64-only, tagged as a branch build, skipped by the image scan), and `security-comprehensive` never ran its push/PR scans. Both now key on `main`. `wiki-publish`'s `git push origin HEAD:master` is deliberately untouched — it pushes to the GitHub wiki repository, which always uses `master`.
- **Cross-arch apk verification** (port of azinchen/nordvpn@cd48451): `update-apk-versions.sh` only checked x86_64 availability, so a version bump Alpine hadn't yet built for all 8 shipped platforms broke the multi-arch build. Bumps are now held back until the version exists on every architecture in `PLATFORMS` (`x86 x86_64 armhf armv7 aarch64 ppc64le s390x riscv64`). The PLATFORM_VERSIONS half of upstream's script is omitted — this Dockerfile has no per-arch package pins. Also fixes the truncated scheduled-scan comment in `security-docker.yml`.