### PR TITLE
Sync wiki and README with current behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Also available from GitHub Container Registry: `ghcr.io/azinchen/nordvpn-wg`
 3. Generate a new **access token** and copy it
 4. Pass it as `TOKEN` — the container reads your NordLynx (WireGuard) key from the NordVPN API on every connect
 
-> **Note**: The token is different from your regular NordVPN login. It is used only to fetch your WireGuard key; the key is never written to disk. See the [wiki][wiki-token] for the API one-liner if you prefer to inspect it yourself.
+> **Note**: The token is different from your regular NordVPN login. It is used only to fetch your WireGuard key; the key lives only in the container-private WireGuard config (root-owned, mode 0600), is removed when the service stops, and is re-fetched on every connect — it is never logged and never stored in the image or a volume. See the [wiki][wiki-token] for the API one-liner if you prefer to inspect it yourself.
 
 ## Docker Compose Example
 
@@ -120,7 +120,7 @@ Pick which servers to connect to; filters combine to narrow the pool. See [Serve
 |---|---|
 | **COUNTRY** | Filter by countries: names, codes, IDs, or server hostnames ([list][nordvpn-countries]). |
 | **CITY** | Filter by cities: names, IDs, or server hostnames ([list][nordvpn-cities]). |
-| **GROUP** | Filter by server group ([list][nordvpn-groups]). |
+| **GROUP** | Filter by server group ([list][nordvpn-groups], [details][wiki-groups]). |
 | **RANDOM_TOP** | Randomize top N servers. Default: `0` |
 
 ### Tunnel & DNS
@@ -200,6 +200,7 @@ Check the **[Troubleshooting][wiki-troubleshoot]** and **[FAQ][wiki-faq]** wiki 
 [wiki-home]: https://github.com/azinchen/nordvpn-wg/wiki
 [wiki-token]: https://github.com/azinchen/nordvpn-wg/wiki/FAQ#credentials
 [wiki-server]: https://github.com/azinchen/nordvpn-wg/wiki/Server-Selection
+[wiki-groups]: https://github.com/azinchen/nordvpn-wg/wiki/Server-Groups
 [wiki-reconnect]: https://github.com/azinchen/nordvpn-wg/wiki/Automatic-Reconnection
 [wiki-security]: https://github.com/azinchen/nordvpn-wg/wiki/Security-Model#traffic-control--kill-switch
 [wiki-network]: https://github.com/azinchen/nordvpn-wg/wiki/Local-Network-Access

--- a/wiki/Architecture-and-Internals.md
+++ b/wiki/Architecture-and-Internals.md
@@ -11,7 +11,9 @@ entrypoint (container start)
   ├─ init-setupcron      Configure cron jobs from RECREATE_VPN_CRON / CHECK_CONNECTION_CRON
   │
   ├─ svc-nordvpn         Main WireGuard service (long-running)
-  └─ svc-cron            Cron daemon (long-running)
+  └─ svc-cron            Cron daemon (long-running; starts only after svc-nordvpn is
+                         launched, so cron can never fire a reconnect or health check
+                         before the first connection attempt)
 ```
 
 ## Key Scripts
@@ -42,9 +44,12 @@ isn't usable in its network namespace (the probe in step 1 decides this).
 Location: `/usr/local/bin/backend-functions`
 
 Sourced by every script. Provides the environment-variable defaults (including `dns`, `network`, `forward_from`, `nordvpnapi_ip`) and:
-- `run4()` / `run6()` — Execute iptables commands with logging (non-fatal)
+- `run4()` / `run6()` — Execute iptables commands with logging (non-fatal, always return 0)
+- `run4_check()` — Like `run4` but propagates the iptables exit status, for callers that branch on whether a rule was actually added
 - `run4_critical()` / `run6_critical()` — Execute or sleep forever on failure
+- `trim()` — Strips whitespace around tokens split from `;`/`,` lists
 - `is_vpn_connected()` — Checks for the `wg0` interface
+- `apply_wireguard_config()` — Shared bring-up: refreshes the `VPN-SERVER` pinhole for the endpoint in `wg0.conf`, swaps the interface with `wg-quick` down/up, and writes `/etc/resolv.conf` from `$dns`; used by both the service start path and `vpn-reconnect`
 - `log()` / `log_error()` / `log_warning()` — Timestamped logging
 - `parse_cron()` — Converts cron expressions to human-readable descriptions
 
@@ -54,16 +59,27 @@ Location: `/usr/local/bin/vpn-config`
 
 1. Fetches your NordLynx (WireGuard) **private key** from the NordVPN API using `TOKEN`
    (`v1/users/services/credentials`), via pinned API IPs (no DNS). The key is not cached —
-   it is re-fetched on every connect.
+   it is re-fetched on every connect. The token is handed to `curl` through a short-lived
+   0600 config file (`-K`), never on the command line.
 2. Resolves COUNTRY/CITY/GROUP to numeric IDs using the JSON data files
 3. Builds the NordVPN API query (always filtered to NordLynx, tech id 35); CITY uses the
    `country_city_id` filter
 4. Fetches the server list using pinned API IPs (no DNS)
-5. Detects specific server hostnames and gives them `load=0`
-6. Sorts by load (multi-location) or keeps API order (single location)
+5. Detects specific server hostnames (`us1234`, `ca-us100`, `nl-onion6`, `socks-nl1`) and
+   looks each up through the API by hostname — again via pinned IPs, no DNS — so the pool
+   entry carries the server's real address, load, and WireGuard public key. Unknown or
+   retired hostnames are skipped with a warning instead of aborting selection.
+6. Sorts by load (multi-location) or keeps API order (single location). If the pool is
+   empty, falls back to the recommended pool — first still honoring `GROUP` (with only
+   `GROUP` set this is the primary query), then once more without the group filter if the
+   group has no NordLynx servers.
 7. Applies `RANDOM_TOP` if set
 8. Writes the selected server's WireGuard config to `/etc/wireguard/wg0.conf` (private key,
-   `Address`, `[Peer]` endpoint + public key, `AllowedIPs = 0.0.0.0/0`, `PersistentKeepalive = 25`)
+   `Address`, `[Peer]` endpoint + public key, `AllowedIPs = 0.0.0.0/0`, `PersistentKeepalive = 25`),
+   atomically via a temp file. With `--fail-fast` (used by `vpn-reconnect`) a fatal error
+   exits non-zero instead of blocking forever, leaving the existing config untouched.
+9. Publishes the selection as machine-readable JSON to `/run/xt/status.json`
+   (best-effort — a write failure never breaks configuration)
 
 ### `svc-nordvpn/run` — WireGuard launcher
 
@@ -93,13 +109,19 @@ Location: `/usr/local/bin/vpn-healthcheck`
 2. Retries `CHECK_CONNECTION_ATTEMPTS` times with configurable interval
 3. If all fail, calls `vpn-reconnect`
 
-### `vpn-reconnect` — Service restart
+### `vpn-reconnect` — Prepare-then-swap reconnection
 
 Location: `/usr/local/bin/vpn-reconnect`
 
-1. Stops `svc-nordvpn` via s6-rc
-2. Waits briefly
-3. Restarts `svc-nordvpn` (which re-fetches the key and picks a new server)
+1. Takes an atomic `mkdir` lock (`/run/xt/vpn-reconnect.lock`) so overlapping triggers —
+   `RECREATE_VPN_CRON`, a health-check reconnect, a manual run — never race; a second
+   invocation logs "Another reconnection (pid N) is already in progress" and exits, and a
+   lock whose owner died mid-run is taken over
+2. Runs `vpn-config --fail-fast` **while the current tunnel stays up** — the API calls and
+   load sorting don't count as downtime, and a failed selection keeps the existing
+   connection and config untouched
+3. Applies the new config via `apply_wireguard_config`: refreshes the firewall pinhole and
+   swaps the interface. The only downtime is the `wg-quick` down/up itself (~1–2 s)
 
 ### `network-diagnostic` — Debug tool
 
@@ -157,9 +179,18 @@ The `init-firewall` service then:
 - Enables connection tracking (ESTABLISHED/RELATED)
 - Sets up MASQUERADE on the `wg0` (VPN) interface
 - Creates a `VPN-SERVER` chain and jumps eth0 UDP/51820 to it
-- Adds NordVPN API IP exceptions (TCP/443 only) from `NORDVPNAPI_IP`
-- If `NETWORK` is set, adds static routes and bidirectional allow rules for those CIDRs
+- Adds NordVPN API IP exceptions (TCP/443 only) from `NORDVPNAPI_IP`, and pins a host
+  route for each API IP out `eth0` — `wg-quick`'s `suppress_prefixlength` rule lets these
+  main-table routes win, so the API stays reachable even when the tunnel is dead and
+  `vpn-reconnect` can always recover
+- If `NETWORK` is set, adds static routes (a failure logs a warning naming the value) and
+  bidirectional allow rules for those CIDRs
 - If `FORWARD_FROM` is set, opens `FORWARD` for those CIDRs over `wg0` (see [VPN Gateway Mode](VPN-Gateway-Mode))
+- If `GATEWAY_DNS` is enabled, installs the client-DNS interception NAT rules for the
+  `FORWARD_FROM` sources: port-53 DNAT to the tunnel resolvers (`redirect`), to the
+  container itself (`local`), or to `GATEWAY_DNS_SERVER` (`forward` — including the
+  startup probe that picks the first candidate answering a DNS query, plus the hairpin
+  MASQUERADE and pinned host route that keep the resolver reachable over the uplink)
 
 ### Phase 3 — svc-nordvpn (per-connection pinhole)
 

--- a/wiki/Automatic-Reconnection.md
+++ b/wiki/Automatic-Reconnection.md
@@ -17,6 +17,8 @@ Use `RECREATE_VPN_CRON` to periodically switch to a different server. This uses 
 
 When triggered, `vpn-reconnect` selects a new server and prepares the new config **while the current tunnel stays up** — the API calls and load sorting no longer count as downtime. Only then is the interface swapped, so the actual interruption is the `wg-quick` down/up itself (about 1–2 seconds). If server selection fails (for example the API is unreachable), the existing connection is kept untouched.
 
+Concurrent reconnections are serialized with a lock: if a scheduled rotation, a health-check reconnect and/or a manual `docker exec vpn vpn-reconnect` overlap, the second run logs `Another reconnection (pid N) is already in progress - skipping` and exits — they never race on the config or the interface swap.
+
 ### Making rotation effective
 
 Server selection always takes the top of the filtered pool (NordVPN's recommended order for a single location, load-sorted for multiple locations). Without further settings a scheduled rotation can therefore re-select the very server you are already on. Set `RANDOM_TOP` so rotation actually lands somewhere new:
@@ -53,7 +55,7 @@ Use the `CHECK_CONNECTION_*` variables for active health probing:
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `CHECK_CONNECTION_CRON` | Disabled | Cron schedule for health checks |
-| `CHECK_CONNECTION_URL` | `https://www.google.com` | URLs to probe (semicolon-separated) |
+| `CHECK_CONNECTION_URL` | `https://www.google.com` | URLs to probe (`;`- or `,`-separated, whitespace ignored) |
 | `CHECK_CONNECTION_ATTEMPTS` | `5` | Number of retry attempts |
 | `CHECK_CONNECTION_ATTEMPT_INTERVAL` | `10` | Seconds between retries |
 

--- a/wiki/Docker-Compose-Examples.md
+++ b/wiki/Docker-Compose-Examples.md
@@ -17,8 +17,8 @@ services:
       - RECREATE_VPN_CRON=0 */6 * * *
       - NETWORK=192.168.1.0/24
     ports:
-      - "8080:8080"
-      - "3000:3000"
+      - "8080:80"                  # nginx webapp (host:container)
+      - "3000:3000"                # node api-service
     restart: unless-stopped
 
   webapp:
@@ -64,10 +64,11 @@ services:
       - RECREATE_VPN_CRON=0 */4 * * *
       - CHECK_CONNECTION_CRON=*/5 * * * *
       - CHECK_CONNECTION_URL=https://1.1.1.1;https://8.8.8.8
+      - HEALTHCHECK_ENABLED=true   # real health status, so service_healthy below gates on it
       - NETWORK=192.168.1.0/24;172.20.0.0/16
     ports:
-      - "8080:8080"
-      - "3000:3000"
+      - "8080:80"                  # nginx webapp (host:container)
+      - "3000:3000"                # node api-service
       - "9000:9000"
       - "6379:6379"
     restart: unless-stopped

--- a/wiki/Docker-Run-Examples.md
+++ b/wiki/Docker-Run-Examples.md
@@ -17,7 +17,7 @@ docker run -d --name app --net=container:vpn nginx
 docker run -d --name vpn \
            --cap-add=NET_ADMIN \
            --sysctl net.ipv4.conf.all.src_valid_mark=1 \
-           -p 8080:8080 \
+           -p 8080:80 \
            -p 9091:9091 \
            -e TOKEN=your_nordvpn_token_here \
            -e COUNTRY="Germany;NL;202" \

--- a/wiki/FAQ.md
+++ b/wiki/FAQ.md
@@ -21,7 +21,7 @@ No. NordVPN does not support inbound port forwarding. You can only access servic
 Read the status file: `docker exec vpn cat /run/xt/status.json` — machine-readable JSON with the selected server's name, hostname, IP, country, city and load. Or check the container logs (`docker logs vpn | grep "Selected server"`) or run the network diagnostic: `docker exec vpn /usr/local/bin/network-diagnostic --basic`.
 
 **Q: Can I connect to a specific server?**
-Yes. Use the server hostname in `COUNTRY` or `CITY`: `-e COUNTRY=es1234` or `-e CITY=uk2567`. Specific servers get priority with `load=0`.
+Yes. Use the server hostname in `COUNTRY` or `CITY`: `-e COUNTRY=es1234` or `-e CITY=uk2567`. The server is looked up through the NordVPN API; list it as the only value to guarantee it is selected. See [Server Selection](Server-Selection#specific-server-hostname-format).
 
 ## Networking
 

--- a/wiki/FAQ.md
+++ b/wiki/FAQ.md
@@ -18,7 +18,7 @@ NordLynx (NordVPN's WireGuard implementation), exclusively. OpenVPN, IKEv2, SOCK
 No. NordVPN does not support inbound port forwarding. You can only access services from your LAN by publishing ports on the VPN container and setting `NETWORK` to include your LAN CIDR.
 
 **Q: How do I know which server I'm connected to?**
-Check the container logs: `docker logs vpn | grep "Selected server"`. Or run the network diagnostic: `docker exec vpn /usr/local/bin/network-diagnostic --basic`.
+Read the status file: `docker exec vpn cat /run/xt/status.json` — machine-readable JSON with the selected server's name, hostname, IP, country, city and load. Or check the container logs (`docker logs vpn | grep "Selected server"`) or run the network diagnostic: `docker exec vpn /usr/local/bin/network-diagnostic --basic`.
 
 **Q: Can I connect to a specific server?**
 Yes. Use the server hostname in `COUNTRY` or `CITY`: `-e COUNTRY=es1234` or `-e CITY=uk2567`. Specific servers get priority with `load=0`.

--- a/wiki/FAQ.md
+++ b/wiki/FAQ.md
@@ -7,7 +7,7 @@ A NordVPN **access token**. Pass it as `TOKEN` and the container reads your acco
 No. You need an access token generated from your Nord Account: [Nord Account Dashboard](https://my.nordaccount.com/) → NordVPN → Manual setup → generate an access token.
 
 **Q: Does the token expire? Is it stored?**
-The token is read at connect time to fetch your WireGuard key from the API; the key itself is never written to disk and is re-fetched on every (re)connect. The WireGuard key is persistent on your account, but the access token has the expiry you chose when generating it — keep it valid (or update `TOKEN` and restart) so reconnects keep working.
+The token is read at connect time to fetch your WireGuard key from the API; the key is written only to the container-private `/etc/wireguard/wg0.conf` (root-owned, mode 0600), removed when the service stops, and re-fetched on every (re)connect — it is never logged and never stored in the image or a volume. The WireGuard key is persistent on your account, but the access token has the expiry you chose when generating it — keep it valid (or update `TOKEN` and restart) so reconnects keep working.
 
 ## Features
 

--- a/wiki/Firewall-Backends.md
+++ b/wiki/Firewall-Backends.md
@@ -33,7 +33,7 @@ When nft isn't usable and the legacy backend is selected:
 
 ## ALLOW_MISSING_IPTABLES_RULES
 
-Some NAS kernels (e.g. Synology DSM 4.4.x) cannot load the netfilter modules behind `wg-quick`'s anti-leak rules with **either** backend — typically `iptable_raw` and the `comment`/`addrtype`/`CONNMARK` extensions. On such hosts `iptables-restore` fails no matter what, `wg-quick` treats that as fatal, and the tunnel is rolled back:
+Some NAS kernels (e.g. Synology DSM hosts on kernel 4.4.x) cannot load the netfilter modules behind `wg-quick`'s anti-leak rules with **either** backend — typically `iptable_raw` and the `comment`/`addrtype`/`CONNMARK` extensions. On such hosts `iptables-restore` fails no matter what, `wg-quick` treats that as fatal, and the tunnel is rolled back:
 
 ```
 [#] iptables-restore -n

--- a/wiki/Local-Network-Access.md
+++ b/wiki/Local-Network-Access.md
@@ -16,7 +16,7 @@ docker run -d --cap-add=NET_ADMIN \
            azinchen/nordvpn-wg
 ```
 
-Multiple CIDRs are semicolon-separated:
+Multiple CIDRs are separated by `;` or `,` (whitespace around separators is ignored):
 
 ```bash
 -e NETWORK="192.168.1.0/24;172.20.0.0/16;10.0.0.0/8"
@@ -26,7 +26,7 @@ Multiple CIDRs are semicolon-separated:
 
 When `NETWORK` is set, the `init-firewall` script:
 
-1. Adds a **static route** for each CIDR via the default gateway (so traffic bypasses the VPN tunnel)
+1. Adds a **static route** for each CIDR via the default gateway (so traffic bypasses the VPN tunnel); a route that cannot be added logs a warning naming the value instead of being skipped silently
 2. Adds **bidirectional iptables rules** allowing traffic to/from those CIDRs
 3. These rules apply **regardless of VPN state** — they remain active even if the VPN drops
 
@@ -67,7 +67,7 @@ services:
       - TOKEN=your_nordvpn_token_here
       - NETWORK=192.168.1.0/24;172.20.0.0/16
     ports:
-      - "8080:8080"
+      - "8080:80"                  # host:container — use your app's listening port
     restart: unless-stopped
 
   app:

--- a/wiki/Network-Diagnostics-Guide.md
+++ b/wiki/Network-Diagnostics-Guide.md
@@ -39,26 +39,46 @@ Produces a comprehensive report covering all sections below.
 ### Header & VPN Status
 
 ```
+================================================================
 WireGuard DIAG (full) : 2026-03-22T16:30:00+00:00
-VPN Status            : CONNECTED
+Kernel                : 6.8.0-45-generic
+VPN Status            : Connected
+WireGuard Engine      : kernel
+Device                : wg0 (type=wireguard)
+Common Name           : de1234.nordvpn.com
+Ifconfig Local        : 10.5.0.2
+Peer IP               : 10.5.0.1
+Peer Endpoint         : 203.0.113.10:51820
+Proto/Local Port      : udp/51820
 ```
 
-VPN status is derived from the `wg0` interface and its peer endpoint.
+`VPN Status` reports `Connected` when the `wg0` interface exists and the `wg` tool is
+available — it does not by itself prove traffic flows (see the Quick verdicts below for
+the handshake check).
+
+### Project Configuration
+
+- `### Project configuration (effective)` — the effective values of every configuration
+  variable (`COUNTRY`, `CITY`, `GROUP`, `DNS`, `NETWORK`, `FORWARD_FROM`, `GATEWAY_DNS`,
+  the `CHECK_CONNECTION_*` set, …) plus the selected firewall backend
 
 ### WireGuard & Connection Info
 
 - `### ip addr show wg0` — tunnel interface address
 - `### wg show` — peer public key, endpoint, last handshake, transfer counters, listening port
 - `### wg0.conf` — the generated config (private key redacted in logs)
+- `### wg0 interface stats (ip -s link)` — packet/byte/error counters
+- `### WireGuard fwmark (wg0)` — the fwmark WireGuard tags its own traffic with
 
 The peer endpoint reported by `wg show` is the VPN server you're connected to.
 
 ### System Network State
 
 - `### ip link (up)` — link states
-- `### ip route (main)` — main routing table
+- `### ip route (main table)` — main routing table
 - `### ip rule` — policy routing rules (WireGuard installs an fwmark rule)
 - `### ip route table 51820` — the WireGuard routing table (default via wg0)
+- `### ip route show table all` — every routing table (IPv4 and IPv6)
 - `### ip route get <test IP>` — which interface a packet to the internet uses (should be wg0)
 
 ### Firewall Rules
@@ -74,6 +94,7 @@ The peer endpoint reported by `wg show` is the VPN server you're connected to.
 ### DNS
 
 - `### DNS configuration` — contents of `/etc/resolv.conf`
+- `### DNS resolution test` — an actual lookup through the configured resolvers
 - `### DNS servers geolocation` — geolocation lookup for each nameserver
 - `### resolver identity via <ns>` — identity probe of the active resolver
 
@@ -81,7 +102,10 @@ The peer endpoint reported by `wg show` is the VPN server you're connected to.
 
 - `### Ping checks` — IPv4/IPv6 reachability
 - `### Short trace to <test IP>` — first hop should be the VPN
-- `### Quick verdicts` — summary checks
+- `### Quick verdicts` — summary checks: whether the route to the internet goes via `wg0`,
+  and **handshake freshness** — `[warn] No WireGuard handshake yet (peer unreachable,
+  stale endpoint, or rate-limited)` flags the classic "interface up, `0 B received`"
+  NordLynx failure, and a handshake older than ~3 minutes is reported as stale
 
 ## IP Resolution Fallback
 

--- a/wiki/Security-Model.md
+++ b/wiki/Security-Model.md
@@ -15,7 +15,7 @@ This page describes the container's firewall behavior, kill switch, and network 
 
 ## Rule Precedence
 
-1. **Bootstrap-only (when VPN is down & before first connect):** Allow HTTPS only to the **NordVPN API IPs from `NORDVPNAPI_IP`** used by the image's bootstrap script.
+1. **API access (always):** Allow HTTPS only to the **NordVPN API IPs from `NORDVPNAPI_IP`**. This pinhole (plus a pinned host route out the uplink) is deliberately permanent, not bootstrap-only: it is what lets `vpn-reconnect` reach the API to fetch a new key and server list when the tunnel is dead.
 2. **Exceptions:** If destination matches `NETWORK` (CIDR), allow (bypass/LAN), regardless of VPN state.
 3. **VPN path:** If VPN is **up** and traffic is not an exception, allow only via the VPN interface.
 4. **Default-deny:** Otherwise, block.
@@ -34,7 +34,7 @@ The NordVPN access token passed via the `TOKEN` environment variable is:
 - Visible via `docker inspect` on the container
 - Visible in the process environment
 
-The token is used only to fetch your WireGuard key from the NordVPN API; it is never written to the WireGuard config. Still, to reduce exposure:
+The token is used only to fetch your WireGuard key from the NordVPN API; it is never written to the WireGuard config, and it is passed to `curl` via a short-lived 0600 config file (`-K`) rather than on the command line, so it does not appear in `ps` output or `/proc/*/cmdline`. Still, to reduce exposure:
 - Use a `.env` file with `env_file:` in Docker Compose (keeps the token out of `docker-compose.yml`)
 - Avoid passing the token directly on the `docker run` command line (visible in process listings)
 - Generate the token with a sensible expiry and rotate it if it may have leaked

--- a/wiki/Server-Groups.md
+++ b/wiki/Server-Groups.md
@@ -1,6 +1,6 @@
 The `GROUP` environment variable filters the NordVPN server fleet by specialty. Each group is a separate set of servers with different capabilities. Only **one** group can be set at a time.
 
-> **NordLynx only:** this container connects with NordLynx (WireGuard). Server lookups are always filtered to NordLynx-capable servers. Groups that historically exist only for OpenVPN (e.g. **Obfuscated / XOR**) have no NordLynx servers — selecting them returns nothing and the container falls back to the recommended pool.
+> **NordLynx only:** this container connects with NordLynx (WireGuard). Server lookups are always filtered to NordLynx-capable servers. Groups that historically exist only for OpenVPN (e.g. **Obfuscated / XOR**) have no NordLynx servers — selecting them returns nothing and the container falls back to the recommended pool without the group filter, logging a warning (`No servers in group ... support WireGuard - retrying without the group filter`).
 
 ## Quick Reference
 

--- a/wiki/Server-Selection.md
+++ b/wiki/Server-Selection.md
@@ -21,30 +21,30 @@ docker run -d --cap-add=NET_ADMIN \
 | **CITY** | Name or numeric ID | `New York`, `8971718` |
 | **Specific server** | Hostname (in COUNTRY or CITY) | `es1234`, `uk2567` |
 
-Multiple values are semicolon-separated: `COUNTRY="United States;CA;228"`
+Multiple values are separated by `;` or `,` (whitespace around separators is ignored): `COUNTRY="United States;CA;228"`
 
 ### Specific Server Hostname Format
 
-To connect to a specific NordVPN server, use its short hostname. The format is:
+To connect to a specific NordVPN server, use its short hostname. Four patterns are recognized (case-insensitive):
 
-```
-<2-letter country code><server number>
-```
+| Pattern | Example | Resolved hostname | Server kind |
+|---------|---------|-------------------|-------------|
+| `<cc><num>` | `us1`, `DE456` | `us1.nordvpn.com` | Standard server |
+| `<cc>-<cc><num>` | `ca-us100`, `uk-fr17` | `ca-us100.nordvpn.com` | Cross-country (Double VPN) |
+| `<cc>-onion<num>` | `nl-onion6` | `nl-onion6.nordvpn.com` | Onion Over VPN |
+| `socks-<cc><num>` | `socks-nl1` | `socks-nl1.nordvpn.com` | SOCKS proxy host |
 
-**Pattern:** Exactly 2 letters followed by 1 or more digits (case-insensitive).
-
-| Input | Resolved hostname | How it works |
-|-------|------------------|---------------|
-| `us1` | `us1.nordvpn.com` | US server #1 |
-| `DE456` | `de456.nordvpn.com` | Germany server #456 |
-| `gb42` | `gb42.nordvpn.com` | UK server #42 |
+(`<cc>` = 2-letter country code, `<num>` = one or more digits.)
 
 Specific servers are:
-- Looked up by hostname against the NordVPN API for their WireGuard endpoint and public key
-- Given `load=0` so they always appear first in the server list
+- Looked up through the NordVPN API by hostname — via the pinned API IPs, never DNS — to obtain their real address, load, and WireGuard public key
+- Added to the pool alongside any other filter results; to guarantee connecting to one, list it as the only value
+- Skipped with a warning (selection continues with the remaining values) if the hostname is unknown or retired
 - Placed in either `COUNTRY` or `CITY` — both work the same way
 
-**Invalid formats** (will be treated as country/city names): `usa1` (3 letters), `u1` (1 letter), `us` (no digits).
+> Only servers with NordLynx (WireGuard) support are usable — a SOCKS/onion host without a WireGuard key cannot be connected to by this image.
+
+**Invalid formats** (will be treated as country/city names): `usa1` (3-letter prefix), `u1` (1 letter), `us` (no digits).
 
 Reference lists:
 - [Countries](Countries-List)
@@ -53,7 +53,7 @@ Reference lists:
 
 ## Selection Behavior
 
-- **Specific servers** (e.g., `es1234`): Placed at the top of the list with `load=0`
+- **Specific servers** (e.g., `es1234`): Join the pool with their real API data; list one alone to force its selection
 - **Multiple locations**: Combined and sorted by server load (lowest first)
 - **Single location**: Keeps NordVPN's recommended order
 - **RANDOM_TOP=N**: After filtering and sorting, randomly picks from the top N servers

--- a/wiki/Troubleshooting.md
+++ b/wiki/Troubleshooting.md
@@ -52,6 +52,14 @@ See [Automatic Reconnection](Automatic-Reconnection#connection-health-monitoring
 
 Docker subnets are **not** auto-allowed. If inter-container communication is needed, include Docker's subnet too.
 
+### Only some NETWORK subnets are reachable
+
+**Symptoms:** With multiple CIDRs in `NETWORK` (or `FORWARD_FROM`), only the first one works; `docker exec vpn ip route` is missing routes for the others.
+
+**Cause:** Older releases did not trim whitespace in list values, so `NETWORK="10.10.0.0/16; 10.20.0.0/16"` (note the space after `;`) silently skipped every value after the first separator. Current images ignore whitespace around separators and log a warning when a route cannot be added.
+
+**Fix:** Update to the latest image, or remove the spaces after `;`/`,`.
+
 ### Torrent client stalled despite a healthy swarm
 
 **Symptoms:** qBittorrent (or another libtorrent-based client) running with `network_mode: "service:vpn"` shows torrents as **stalled** with 0 peers, while the swarm has plenty of seeds. Ordinary outbound traffic from the namespace (e.g. `curl`) works fine.
@@ -116,6 +124,8 @@ Pass the `net.ipv4.conf.all.src_valid_mark=1` sysctl (or run `privileged: true`)
 2. **Logs:** Look for `[INIT-SETUPCRON]` lines at startup — they show the parsed schedule in human-readable format.
 3. **Crontab:** `docker exec vpn cat /var/spool/cron/crontabs/root`
 
+Note: invalid `CHECK_CONNECTION_ATTEMPTS` / `CHECK_CONNECTION_ATTEMPT_INTERVAL` values (non-numeric or zero) are rejected at startup — `init-setupcron` logs an ERROR naming the variable and the container does not come up, rather than running with a broken health check.
+
 ## Diagnostics
 
 ### Built-in Network Diagnostics
@@ -156,6 +166,7 @@ Key log messages:
 ### Inspecting the Container
 
 ```bash
+docker exec vpn cat /run/xt/status.json      # selected server (name, hostname, ip, country, city, load)
 docker exec vpn wg show wg0                  # WireGuard peer/handshake/transfer
 docker exec vpn ip route                     # view routing table
 docker exec vpn iptables -S                   # check iptables rules

--- a/wiki/Troubleshooting.md
+++ b/wiki/Troubleshooting.md
@@ -151,7 +151,7 @@ Key log messages:
 | `[VPN-CONFIG] Selected server ...` | Selected VPN server |
 | `[SERVICE-NORDVPN] VPN connected successfully` | `wg0` came up (verify with a handshake) |
 | `[SERVICE-NORDVPN] VPN connection timeout` | Tunnel didn't establish in time |
-| `[HEALTHCHECK] Connection check failed` | Health check triggered reconnection |
+| `[VPN-HEALTHCHECK] All connection attempts failed, triggering VPN reconnection` | Health check triggered reconnection |
 
 ### Inspecting the Container
 


### PR DESCRIPTION
Documentation sweep from the audit, aligned with the code as of #230/#231. Docs only — 13 files, 4 commits:

**Corrected claims**
- "The key is never written to disk" (README, FAQ) → the key lives only in the container-private `/etc/wireguard/wg0.conf` (0600), is removed on service stop and re-fetched on every connect.
- Security-Model: the API pinhole + eth0 host routes are documented as permanent by design (recovery path for a dead tunnel), not "bootstrap-only"; token now noted as passed to curl via a 0600 config file, never on a command line.
- Troubleshooting quoted a log line that doesn't exist; now matches `VPN-HEALTHCHECK`'s real output. Firewall-Backends "DSM 4.4.x" clarified to kernel 4.4.x.

**Architecture & diagnostics sync**
- vpn-reconnect section rewritten: prepare-then-swap (selection while the tunnel stays up, ~1–2 s swap window), mkdir lock with stale-owner takeover; backend-functions list gains `trim`/`run4_check`/`apply_wireguard_config`; vpn-config steps now cover `--fail-fast`, the `-K` token file, API-based specific-server lookup, the two-stage group fallback and the status.json publish; boot diagram shows svc-cron waiting on svc-nordvpn; firewall Phase 2 includes the API host routes and GATEWAY_DNS rules.
- Network-Diagnostics-Guide sample output and section list regenerated against the actual script, including the handshake-freshness verdict.

**New features documented**
- `/run/xt/status.json` in FAQ + Troubleshooting; the reconnect lock in Automatic-Reconnection; startup abort on invalid `CHECK_CONNECTION_*`; whitespace-in-lists troubleshooting entry (adapted from upstream 94920b2).

**Server selection & examples**
- Server-Selection documents all four specific-server hostname patterns (`us1234`, `socks-nl1`, `nl-onion6`, `ca-us100`, adapted from upstream cd43258), the API-based lookup, and skip-with-warning behavior; Server-Groups describes the two-stage fallback; nginx examples fixed to `8080:80`; the `service_healthy` example now sets `HEALTHCHECK_ENABLED=true` so the gate is real.

One behavior note surfaced while writing: since #230 specific servers carry their real API load instead of a hard-coded `load=0`, so they are no longer implicitly pinned to the front of a mixed pool — the docs describe the actual behavior (list the server alone to force it). If pin-first is preferred, it's a one-line follow-up (`jq '.load = 0'` on the specific-server JSON).